### PR TITLE
Safari needs header, otherwise complains http/0.9

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,6 +134,7 @@ bool handleStatusServerRequests() {
   WiFiClient client = statusServer.available();
 
   if (client.availableForWrite() >= AVAILABLE_THRESHOLD) {
+    client.printf("HTTP/1.1 200 OK\r\n\r\n");
     client.printf("uptime: %ld ms\n", millis());
     client.printf("rssi: %d dBm\n", WiFi.RSSI());
     client.printf("free_heap: %d B\n", ESP.getFreeHeap());


### PR DESCRIPTION
Safari needs the header HTTP/1.1 200 OK, otherwise it rejects the connection with "Cancelled load ... because it is using http/0.9"