### PR TITLE
Track.touch() added; missing tracked values fixed

### DIFF
--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -75,6 +75,10 @@ class Track {
 
   void publish() { publish(true); }
 
+  void touch() {
+    if (millis() > m_last + m_maxage * 1000) publish(true);
+  }
+
  private:
   T m_value;
   const char *m_topic;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -493,6 +493,8 @@ void publishValues() {
   free_heap = ESP.getFreeHeap();
 
   // ebus/device/wifi
+  last_connect.touch();
+  reconnect_count.touch();
   rssi = WiFi.RSSI();
 
   // ebus/arbitration


### PR DESCRIPTION
 last_connect and reconnect_count were never transmitted to the mqtt service. This behavior is fixed with these changes.