### PR TITLE
incorrect use of serial buffer status corrected

### DIFF
--- a/include/schedule.hpp
+++ b/include/schedule.hpp
@@ -49,8 +49,8 @@ class Schedule {
   std::deque<std::vector<uint8_t>> sendCommands;
   std::vector<uint8_t> sendCommand;
 
-  static bool busReadyCallback();
-  static void busWriteCallback(const uint8_t byte);
+  static void writeCallback(const uint8_t byte);
+  static int readBufferCallback();
 
   static void activeCallback(const std::vector<uint8_t> &master,
                              const std::vector<uint8_t> &slave);

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#6eea915
+    https://github.com/yuhu-/ebus#f7d00b9
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#e57360f
+    https://github.com/yuhu-/ebus#56e782c
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#f7d00b9
+    https://github.com/yuhu-/ebus#e57360f
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#7a8b223
+    https://github.com/yuhu-/ebus#6eea915
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -56,7 +56,7 @@ Track<uint32_t> requestsError("ebus/requests/error", 10);
 Schedule schedule;
 
 Schedule::Schedule()
-    : ebusHandler(0xff, &busReadyCallback, &busWriteCallback, &activeCallback,
+    : ebusHandler(0xff, &writeCallback, &readBufferCallback, &activeCallback,
                   &passiveCallback, &reactiveCallback) {
   ebusHandler.setErrorCallback(errorCallback);
 }
@@ -197,9 +197,9 @@ void Schedule::publishCounters() {
   requestsError = counters.requestsError;
 }
 
-bool Schedule::busReadyCallback() { return Bus.availableForWrite(); }
+void Schedule::writeCallback(const uint8_t byte) { Bus.write(byte); }
 
-void Schedule::busWriteCallback(const uint8_t byte) { Bus.write(byte); }
+int Schedule::readBufferCallback() { return Bus.available(); }
 
 void Schedule::activeCallback(const std::vector<uint8_t> &master,
                               const std::vector<uint8_t> &slave) {

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -43,6 +43,7 @@ Track<uint32_t> errorsActiveSlaveACK("ebus/errors/active/slaveACK", 10);
 // resets
 Track<uint32_t> resetsTotal("ebus/resets/total", 10);
 Track<uint32_t> resetsPassive00("ebus/resets/passive00", 10);
+Track<uint32_t> resetsPassive0704("ebus/resets/passive0704", 10);
 Track<uint32_t> resetsPassive("ebus/resets/passive", 10);
 Track<uint32_t> resetsActive("ebus/resets/active", 10);
 
@@ -186,6 +187,7 @@ void Schedule::publishCounters() {
   // resets
   resetsTotal = counters.resetsTotal;
   resetsPassive00 = counters.resetsPassive00;
+  resetsPassive0704 = counters.resetsPassive0704;
   resetsPassive = counters.resetsPassive;
   resetsActive = counters.resetsActive;
 


### PR DESCRIPTION
- The inadvertent use of bus.availableForWrite() instead of bus.available() led to delays 
-- incorrect use of serial buffer status corrected
- ebus library simplifications (library updaed)
-- unnecessary if's removed in ebus library
-- set lockCounter inside of resetActive
-- call passiveErrors or activeErrors when an error occurs
- Scan of non-existent addresses led to resets 
-- counter for failed 0704 added