### PR TITLE
Enable writing to eBUS by default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -710,17 +710,14 @@ void setup() {
 #endif
 
   ArduinoOTA.begin();
-
   MDNS.begin(HOSTNAME);
-
   wdt_start();
 
   last_comms = millis();
+  enableTX();
 
 #ifdef EBUS_INTERNAL
   store.loadCommands();  // install saved commands
-  if (store.active()) enableTX();
-
   mqtt.publishHASensors(false);
 #endif
 
@@ -767,10 +764,6 @@ void loop() {
 #endif
   }
 
-#ifdef EBUS_INTERNAL
-  if (store.active()) enableTX();
-#endif
-
   uptime = millis();
 
   if (millis() > last_comms + 200 * 1000) {
@@ -786,12 +779,7 @@ void loop() {
   }
 
   // Check if there are any new clients on the eBUS servers
-  if (handleNewClient(&wifiServer, serverClients)) {
-    enableTX();
-  }
-  if (handleNewClient(&wifiServerEnh, enhClients)) {
-    enableTX();
-  }
-
+  handleNewClient(&wifiServer, serverClients);
+  handleNewClient(&wifiServerEnh, enhClients);
   handleNewClient(&wifiServerRO, serverClientsRO);
 }


### PR DESCRIPTION
At the beginning of setup(), writing to the eBUS is disabled and re-enabled at the end. In the main loop, writing is enabled as soon as a write or enhanced client establishes a connection. Write access is not enabled for read-only clients. However, this activation is unnecessary, since a read-only client is never polled for new data. I also believe that the disabling and re-enabling could be removed in setup. A global enabling should suffice.

```
void data_process() {
  loop_duration();

  // check clients for data
  for (int i = 0; i < MAX_SRV_CLIENTS; i++) {
    handleClient(&serverClients[i]);
    handleEnhClient(&enhClients[i]);
  } 
```