### PR TITLE
Redesign of data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,14 @@ payload:
     {
       "key": "01",                       // unique key of command
       "command": "fe070009",             // ebus command as vector of "ZZPBSBNNDBx"
-      "unit": "°C",                      // unit of the received data
+      "unit": "°C",                      // unit of the interested part
       "active": false,                   // active sending of command
       "interval": 0,                     // minimum interval between two commands in seconds
       "master": true,                    // value of interest is in master or slave part
-      "position": 1,                     // starting byte in interested part
+      "position": 1,                     // starting position in the interested part
       "datatype": "DATA2B",              // ebus datatype
+      "divider": 1,                      // divider for value conversion
+      "digits": 2,                       // deciaml digits of value
       "topic": "outdoor_temperature",    // mqtt topic below "values/"
       "ha": true,                        // home assistant support for auto discovery
       "ha_class": "temperature"          // home assistant device_class
@@ -316,10 +318,12 @@ payload:
   ]
 }
 
-ebus datatype: BCD, UINT8, INT8, UINT16, INT16, UINT32, INT32, DATA1B, DATA1C, DATA2B, DATA2C, FLOAT (values as 1/1000)
+ebus datatypes: 
+- numeric: BCD, UINT8, INT8, DATA1B, DATA1C, UINT16, INT16, DATA2B, DATA2C, UINT32, INT32, FLOAT (values as 1/1000)
+- character: CHAR1, CHAR2, CHAR3, CHAR4, CHAR5, CHAR6, CHAR7, CHAR8
 ```
 ```
-mosquitto_pub -h server -t 'ebus/8406ac/request' -m '{"id":"insert","commands":[{"key":"01","command":"fe070009","unit":"°C","active":false,"interval":0,"master":true,"position":1,"datatype":"DATA2B","topic":"outdoor/temperature","ha":true,"ha_class":"temperature"}]}'
+mosquitto_pub -h server -t 'ebus/8406ac/request' -m '{"id":"insert","commands":[{"key":"01","command":"fe070009","unit":"°C","active":false,"interval":0,"master":true,"position":1,"datatype":"DATA2B","divider":1,"digits":2,"topic":"outdoor/temperature","ha":true,"ha_class":"temperature"}]}'
 ```
 
 **Removing installed commands**

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -5,10 +5,12 @@
 #include <deque>
 #include <string>
 #include <tuple>
+#include <vector>
 
 #include "store.hpp"
 
-// The Mqtt class acts as a wrapper for the entire MQTT subsystem.
+// The MQTT class acts as a wrapper for the entire MQTT subsystem. It provides
+// some basic methods for supporting Home Assistant.
 
 class Mqtt {
  public:
@@ -35,6 +37,12 @@ class Mqtt {
 
   void publishCommands();
   void publishHASensors(const bool remove);
+
+  static void publishData(const std::string &id,
+                          const std::vector<uint8_t> &master,
+                          const std::vector<uint8_t> &slave);
+
+  static void publishValue(Command *command, const JsonDocument &doc);
 
  private:
   AsyncMqttClient client;

--- a/include/schedule.hpp
+++ b/include/schedule.hpp
@@ -51,15 +51,15 @@ class Schedule {
   bool forward = false;
   std::vector<std::vector<uint8_t>> forwardfilters;
 
-  static void writeCallback(const uint8_t byte);
-  static int readBufferCallback();
+  static void onWriteCallback(const uint8_t byte);
+  static int isDataAvailableCallback();
 
-  static void publishCallback(const ebus::Message &message,
+  static void onTelegramCallback(const ebus::Message &message,
                               const ebus::Type &type,
                               const std::vector<uint8_t> &master,
                               std::vector<uint8_t> *const slave);
 
-  static void errorCallback(const std::string &str);
+  static void onErrorCallback(const std::string &str);
 
   void processActive(const std::vector<uint8_t> &master,
                      const std::vector<uint8_t> &slave);

--- a/include/schedule.hpp
+++ b/include/schedule.hpp
@@ -11,10 +11,12 @@
 
 #include "store.hpp"
 
-// This class sends time-controlled active commands to the ebus. All valid
-// received messages are compared with passively defined commands and evaluated
-// if they match. Individual commands are transmitted and the results reported
-// back. Raw data (including filter function) can also be output.
+// Active commands are sent on the eBUS at scheduled intervals, and the received
+// data is saved. Passive received messages are compared against defined
+// commands, and if they match, the received data is also saved. Furthermore, it
+// is possible to send individual commands to the eBUS. The results are returned
+// along with the command as raw data. Defined messages (filter function) can be
+// forwarded.
 
 class Schedule {
  public:
@@ -61,14 +63,9 @@ class Schedule {
 
   void processActive(const std::vector<uint8_t> &master,
                      const std::vector<uint8_t> &slave);
+
   void processPassive(const std::vector<uint8_t> &master,
                       const std::vector<uint8_t> &slave);
-
-  static void publishResponse(const std::string &id,
-                              const std::vector<uint8_t> &master,
-                              const std::vector<uint8_t> &slave);
-
-  static void publishValue(Command *command, const std::vector<uint8_t> &value);
 };
 
 extern Schedule schedule;

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#f6c5732
+    https://github.com/yuhu-/ebus#1205d46
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#d7e23dc
+    https://github.com/yuhu-/ebus#f6c5732
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,6 +459,10 @@ char* status_string() {
                   ebus_address);
   pos += snprintf(status + pos, sizeof(status), "command_distance: %i\r\n",
                   atoi(command_distance));
+  pos += snprintf(status + pos, sizeof(status), "active_commands: %i\r\n",
+                  store.getActiveCommands());
+  pos += snprintf(status + pos, sizeof(status), "passive_commands: %i\r\n",
+                  store.getPassiveCommands());
 #endif
 
   pos += snprintf(status + pos, sizeof(status), "mqtt_connected: %s\r\n",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,6 +480,11 @@ void handleCommands() {
   configServer.send(200, "application/json;charset=utf-8",
                     store.getCommandsJson().c_str());
 }
+
+void handleValues() {
+  configServer.send(200, "application/json;charset=utf-8",
+                    store.getValuesJson().c_str());
+}
 #endif
 
 void publishStatus() {
@@ -560,7 +565,12 @@ void handleRoot() {
        "user-scalable=no\"/>";
   s += "</head><body>";
   s += "<a href='/status'>Adapter status</a><br>";
+
+#ifdef EBUS_INTERNAL
   s += "<a href='/commands'>Commands</a><br>";
+  s += "<a href='/values'>Values</a><br>";
+#endif
+
   s += "<a href='/config'>Configuration</a> - user: admin password: your "
        "configured AP mode password or default: ";
   s += DEFAULT_APMODE_PASS;
@@ -670,6 +680,7 @@ void setup() {
 
 #ifdef EBUS_INTERNAL
   configServer.on("/commands", [] { handleCommands(); });
+  configServer.on("/values", [] { handleValues(); });
 #endif
 
   configServer.on("/config", [] { iotWebConf.handleConfig(); });

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -240,7 +240,7 @@ void Schedule::errorCallback(const std::string &str) {
 void Schedule::processActive(const std::vector<uint8_t> &master,
                              const std::vector<uint8_t> &slave) {
   if (send) {
-    mqtt.publishData("send", sendCommand, slave);
+    mqtt.publishData("send", master, slave);
   } else {
     store.updateData(scheduleCommand, master, slave);
     mqtt.publishValue(scheduleCommand, store.getValueJson(scheduleCommand));

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -189,7 +189,6 @@ void Schedule::publishCallback(const ebus::Message &message,
                                const ebus::Type &type,
                                const std::vector<uint8_t> &master,
                                std::vector<uint8_t> *const slave) {
-  std::vector<uint8_t> search;
   switch (message) {
     case ebus::Message::active:
       schedule.processActive(std::vector<uint8_t>(master),
@@ -219,7 +218,7 @@ void Schedule::publishCallback(const ebus::Message &message,
           // rr...Revision (BCD)
           // vv...Hardware version (BCD)
           // hh...Revision (BCD)
-          // search = {0x07, 0x04};
+          // std::vector<uint8_t> search = {0x07, 0x04};
           // if (ebus::Sequence::contains(master, search))
           //   *slave = ebus::Sequence::to_vector("0ahhggggggggggssrrhhrr");
 
@@ -240,10 +239,12 @@ void Schedule::errorCallback(const std::string &str) {
 
 void Schedule::processActive(const std::vector<uint8_t> &master,
                              const std::vector<uint8_t> &slave) {
-  if (send)
-    publishResponse("send", sendCommand, slave);
-  else
-    publishValue(scheduleCommand, slave);
+  if (send) {
+    mqtt.publishData("send", sendCommand, slave);
+  } else {
+    store.updateData(scheduleCommand, master, slave);
+    mqtt.publishValue(scheduleCommand, store.getValueJson(scheduleCommand));
+  }
 }
 
 void Schedule::processPassive(const std::vector<uint8_t> &master,
@@ -254,97 +255,12 @@ void Schedule::processPassive(const std::vector<uint8_t> &master,
                                    return ebus::Sequence::contains(master, vec);
                                  });
     if (count > 0 || forwardfilters.size() == 0)
-      publishResponse("forward", master, slave);
+      mqtt.publishData("forward", master, slave);
   }
 
-  std::vector<Command *> pasCommands = store.findPassiveCommands(master);
+  std::vector<Command *> pasCommands = store.updateData(nullptr, master, slave);
+
   for (Command *command : pasCommands) {
-    if (command->master)
-      publishValue(command,
-                   ebus::Sequence::range(master, 4, master.size() - 4));
-    else
-      publishValue(command, slave);
+    mqtt.publishValue(command, store.getValueJson(command));
   }
-}
-
-void Schedule::publishResponse(const std::string &id,
-                               const std::vector<uint8_t> &master,
-                               const std::vector<uint8_t> &slave) {
-  std::string payload;
-  JsonDocument doc;
-  doc["id"] = id;
-  doc["master"] = ebus::Sequence::to_string(master);
-  doc["slave"] = ebus::Sequence::to_string(slave);
-  serializeJson(doc, payload);
-  mqtt.publish("response", 0, false, payload.c_str());
-}
-
-void Schedule::publishValue(Command *command,
-                            const std::vector<uint8_t> &value) {
-  command->last = millis();
-  JsonDocument doc;
-
-  switch (command->datatype) {
-    case ebus::Datatype::BCD:
-      doc["value"] =
-          ebus::byte_2_bcd(ebus::Sequence::range(value, command->position, 1));
-      break;
-    case ebus::Datatype::UINT8:
-      doc["value"] = ebus::byte_2_uint8(
-          ebus::Sequence::range(value, command->position, 1));
-      break;
-    case ebus::Datatype::INT8:
-      doc["value"] =
-          ebus::byte_2_int8(ebus::Sequence::range(value, command->position, 1));
-      break;
-    case ebus::Datatype::UINT16:
-      doc["value"] = ebus::byte_2_uint16(
-          ebus::Sequence::range(value, command->position, 2));
-      break;
-    case ebus::Datatype::INT16:
-      doc["value"] = ebus::byte_2_int16(
-          ebus::Sequence::range(value, command->position, 2));
-      break;
-    case ebus::Datatype::UINT32:
-      doc["value"] = ebus::byte_2_uint32(
-          ebus::Sequence::range(value, command->position, 4));
-      break;
-    case ebus::Datatype::INT32:
-      doc["value"] = ebus::byte_2_int32(
-          ebus::Sequence::range(value, command->position, 4));
-      break;
-    case ebus::Datatype::DATA1B:
-      doc["value"] = ebus::byte_2_data1b(
-          ebus::Sequence::range(value, command->position, 1));
-      break;
-    case ebus::Datatype::DATA1C:
-      doc["value"] = ebus::byte_2_data1c(
-          ebus::Sequence::range(value, command->position, 1));
-      break;
-    case ebus::Datatype::DATA2B:
-      doc["value"] = ebus::byte_2_data2b(
-          ebus::Sequence::range(value, command->position, 2));
-      break;
-    case ebus::Datatype::DATA2C:
-      doc["value"] = ebus::byte_2_data2c(
-          ebus::Sequence::range(value, command->position, 2));
-      break;
-    case ebus::Datatype::FLOAT:
-      doc["value"] = ebus::byte_2_float(
-          ebus::Sequence::range(value, command->position, 2));
-      break;
-    default:
-      break;
-  }
-
-  std::string payload;
-  serializeJson(doc, payload);
-
-  std::string name = command->topic;
-  std::transform(name.begin(), name.end(), name.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-
-  std::string topic = "values/" + name;
-
-  mqtt.publish(topic.c_str(), 0, false, payload.c_str());
 }

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -3,8 +3,6 @@
 #include <Preferences.h>
 #include <Sequence.h>
 
-#include <sstream>
-
 Store store;
 
 Command Store::createCommand(const JsonDocument &doc) {

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -3,23 +3,38 @@
 #include <Preferences.h>
 #include <Sequence.h>
 
+#include <sstream>
+
 Store store;
 
 Command Store::createCommand(const JsonDocument &doc) {
   Command command;
-
+  // TODO(yuhu-): check incoming data for completeness
   command.key = doc["key"].as<std::string>();
   command.command = ebus::Sequence::to_vector(doc["command"].as<std::string>());
   command.unit = doc["unit"].as<std::string>();
   command.active = doc["active"].as<bool>();
-  command.interval = doc["interval"].as<uint32_t>();
+  command.interval =
+      doc["interval"].isNull() ? 60 : doc["interval"].as<uint32_t>();
   command.last = 0;
+  command.data = std::vector<uint8_t>();
   command.master = doc["master"].as<bool>();
   command.position = doc["position"].as<size_t>();
-  command.datatype = ebus::string2datatype(doc["datatype"].as<const char *>());
+  command.datatype =
+      ebus::string_2_datatype(doc["datatype"].as<const char *>());
+  command.length = ebus::sizeof_datatype(command.datatype);
+  command.numeric = ebus::typeof_datatype(command.datatype);
+  command.divider =
+      doc["divider"].isNull()
+          ? 1
+          : (doc["divider"].as<float>() > 0 ? doc["divider"].as<float>() : 1);
+  command.digits = doc["digits"].isNull() ? 2 : doc["digits"].as<uint8_t>();
   command.topic = doc["topic"].as<std::string>();
-  command.ha = doc["ha"].as<bool>();
-  command.ha_class = doc["ha_class"].as<std::string>();
+  command.ha = doc["ha"].isNull() ? false : doc["ha"].as<bool>();
+  command.ha_class =
+      command.ha
+          ? (doc["ha_class"].isNull() ? "" : doc["ha_class"].as<std::string>())
+          : "";
 
   return command;
 }
@@ -111,31 +126,37 @@ int64_t Store::wipeCommands() {
   return bytes;
 }
 
+JsonDocument Store::getCommandJson(const Command *command) {
+  JsonDocument doc;
+
+  doc["key"] = command->key;
+  doc["command"] = ebus::Sequence::to_string(command->command);
+  doc["unit"] = command->unit;
+  doc["active"] = command->active;
+  doc["interval"] = command->interval;
+  doc["master"] = command->master;
+  doc["position"] = command->position;
+  doc["datatype"] = ebus::datatype_2_string(command->datatype);
+  doc["divider"] = command->divider;
+  doc["digits"] = command->digits;
+  doc["topic"] = command->topic;
+  doc["ha"] = command->ha;
+  doc["ha_class"] = command->ha_class;
+
+  doc.shrinkToFit();
+  return doc;
+}
+
 const std::string Store::getCommandsJson() const {
   std::string payload;
   JsonDocument doc;
 
   if (allCommands.size() > 0) {
-    for (const Command &command : allCommands) {
-      JsonObject obj = doc.add<JsonObject>();
-
-      obj["key"] = command.key;
-      obj["command"] = ebus::Sequence::to_string(command.command);
-      obj["unit"] = command.unit;
-      obj["active"] = command.active;
-      obj["interval"] = command.interval;
-      obj["master"] = command.master;
-      obj["position"] = command.position;
-      obj["datatype"] = ebus::datatype2string(command.datatype);
-      obj["topic"] = command.topic;
-      obj["ha"] = command.ha;
-      obj["ha_class"] = command.ha_class;
-    }
+    for (const Command &command : allCommands)
+      doc.add(getCommandJson(&command));
   }
 
-  if (doc.isNull()) {
-    doc.to<JsonArray>();
-  }
+  if (doc.isNull()) doc.to<JsonArray>();
 
   doc.shrinkToFit();
   serializeJson(doc, payload);
@@ -192,6 +213,72 @@ std::vector<Command *> Store::findPassiveCommands(
   return commands;
 }
 
+std::vector<Command *> Store::updateData(Command *command,
+                                         const std::vector<uint8_t> &master,
+                                         const std::vector<uint8_t> &slave) {
+  std::vector<Command *> commands;
+
+  if (command == nullptr)
+    commands = findPassiveCommands(master);
+  else
+    commands.push_back(command);
+
+  for (Command *cmd : commands) {
+    cmd->last = millis();
+
+    if (cmd->master)
+      cmd->data = ebus::Sequence::range(master, 4 + cmd->position, cmd->length);
+    else
+      cmd->data = ebus::Sequence::range(slave, cmd->position, cmd->length);
+  }
+
+  return commands;
+}
+
+JsonDocument Store::getValueJson(const Command *command) {
+  JsonDocument doc;
+
+  if (command->numeric)
+    doc["value"] = store.getValueDouble(command);
+  else
+    doc["value"] = store.getValueString(command);
+
+  doc.shrinkToFit();
+  return doc;
+}
+
+const std::string Store::getValuesJson() const {
+  std::string payload;
+  JsonDocument doc;
+
+  JsonArray results = doc["results"].to<JsonArray>();
+
+  if (allCommands.size() > 0) {
+    size_t index = 0;
+    uint32_t now = millis();
+
+    for (const Command &command : allCommands) {
+      JsonArray array = results[index][command.key].to<JsonArray>();
+      if (command.numeric)
+        array.add(store.getValueDouble(&command));
+      else
+        array.add(store.getValueString(&command));
+
+      array.add(command.unit);
+      array.add(command.topic);
+      array.add(static_cast<uint32_t>((now - command.last) / 1000));
+      index++;
+    }
+  }
+
+  if (doc.isNull()) doc.to<JsonArray>();
+
+  doc.shrinkToFit();
+  serializeJson(doc, payload);
+
+  return payload;
+}
+
 void Store::countCommands() {
   activeCommands = std::count_if(allCommands.begin(), allCommands.end(),
                                  [](const Command &cmd) { return cmd.active; });
@@ -214,7 +301,9 @@ const std::string Store::serializeCommands() const {
       array.add(command.interval);
       array.add(command.master);
       array.add(command.position);
-      array.add(ebus::datatype2string(command.datatype));
+      array.add(ebus::datatype_2_string(command.datatype));
+      array.add(command.divider);
+      array.add(command.digits);
       array.add(command.topic);
       array.add(command.ha);
       array.add(command.ha_class);
@@ -248,11 +337,67 @@ void Store::deserializeCommands(const char *payload) {
       tmpDoc["master"] = variant[5];
       tmpDoc["position"] = variant[6];
       tmpDoc["datatype"] = variant[7];
-      tmpDoc["topic"] = variant[8];
-      tmpDoc["ha"] = variant[9];
-      tmpDoc["ha_class"] = variant[10];
+      tmpDoc["divider"] = variant[8];
+      tmpDoc["digits"] = variant[9];
+      tmpDoc["topic"] = variant[10];
+      tmpDoc["ha"] = variant[11];
+      tmpDoc["ha_class"] = variant[12];
 
       insertCommand(createCommand(tmpDoc));
     }
   }
+}
+
+const double Store::getValueDouble(const Command *command) {
+  double value = 0;
+
+  switch (command->datatype) {
+    case ebus::Datatype::BCD:
+      value = ebus::byte_2_bcd(command->data);
+      break;
+    case ebus::Datatype::UINT8:
+      value = ebus::byte_2_uint8(command->data);
+      break;
+    case ebus::Datatype::INT8:
+      value = ebus::byte_2_int8(command->data);
+      break;
+    case ebus::Datatype::UINT16:
+      value = ebus::byte_2_uint16(command->data);
+      break;
+    case ebus::Datatype::INT16:
+      value = ebus::byte_2_int16(command->data);
+      break;
+    case ebus::Datatype::UINT32:
+      value = ebus::byte_2_uint32(command->data);
+      break;
+    case ebus::Datatype::INT32:
+      value = ebus::byte_2_int32(command->data);
+      break;
+    case ebus::Datatype::DATA1B:
+      value = ebus::byte_2_data1b(command->data);
+      break;
+    case ebus::Datatype::DATA1C:
+      value = ebus::byte_2_data1c(command->data);
+      break;
+    case ebus::Datatype::DATA2B:
+      value = ebus::byte_2_data2b(command->data);
+      break;
+    case ebus::Datatype::DATA2C:
+      value = ebus::byte_2_data2c(command->data);
+      break;
+    case ebus::Datatype::FLOAT:
+      value = ebus::byte_2_float(command->data);
+      break;
+    default:
+      break;
+  }
+
+  value = value / command->divider;
+  value = ebus::round_digits(value, command->digits);
+
+  return value;
+}
+
+const std::string Store::getValueString(const Command *command) {
+  return ebus::byte_2_string(command->data);
 }


### PR DESCRIPTION
– Added additional configuration parameters "divider" and "digits"
– Saving raw data instead of already converted data
– Added support for numeric and character-based eBUS data types
– Conversion, scaling, and rounding of numeric data types during delivery
– Added HTTP endpoint "/values"
– Methods for publishing data moved from Schedule to Mqtt
– Added active/passive commands info to status page
– Callbacks renamed