### PR TITLE
EBUS_INTERNAL only

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Available MQTT commands.
 |participants     |Publishing scanned ebus participants                          |x
 |send             |Sending ebus commands once                                    |x
 |forward          |Activate/deactivate data forwarding (including filtering)     |x
+|reset            |Resetting counter and timing values                           |x
 
 
 ### Examples
@@ -452,6 +453,18 @@ mosquitto_pub -h server -t 'ebus/8406ac/request' -m '{"id":"forward","value":tru
 ```
 ```
 mosquitto_pub -h server -t 'ebus/8406ac/request' -m '{"id":"forward","value":false}'
+```
+
+**Resetting counter and timing values **
+```
+payload:
+{
+  "id": "reset",
+  "value": true
+}
+```
+```
+mosquitto_pub -h server -t 'ebus/8406ac/request' -m '{"id":"reset","value":true}' 
 ```
 
 ### Home Assistant Support

--- a/include/bus.hpp
+++ b/include/bus.hpp
@@ -26,7 +26,7 @@ bool setArbitrationClient(WiFiClient*& client, uint8_t& address);
 void arbitrationDone();
 WiFiClient* arbitrationRequested(uint8_t& address);
 
-#ifdef ESP32
+#if defined(ESP32)
 #include "atomic"
 #define ATOMIC_INT std::atomic<int>
 #else

--- a/include/busisr.hpp
+++ b/include/busisr.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#if defined(EBUS_INTERNAL)
+#include <Ebus.h>
+
+extern ebus::Handler* ebusHandler;
+extern ebus::ServiceRunner* serviceRunner;
+
+void setupBusIsr();
+void setRequestWindow(const uint16_t& delay);
+#endif

--- a/include/main.hpp
+++ b/include/main.hpp
@@ -7,11 +7,13 @@
 
 #define MAX_SRV_CLIENTS 4
 
-#ifdef ESP32
+#if defined(ESP32)
 #define UART_TX 20
 #define UART_RX 21
+#if !defined(EBUS_INTERNAL)
 #define USE_SOFTWARE_SERIAL 1
-#define USE_ASYNCHRONOUS 1     // requires USE_SOFTWARE_SERIAL
+#define USE_ASYNCHRONOUS 1  // requires USE_SOFTWARE_SERIAL
+#endif
 #define AVAILABLE_THRESHOLD 0  // https://esp32.com/viewtopic.php?t=19788
 #else
 #define UART_TX 1
@@ -24,11 +26,11 @@
 inline int DEBUG_LOG(const char *format, ...) { return 0; }
 int DEBUG_LOG_IMPL(const char *format, ...);
 // #define DEBUG_LOG DEBUG_LOG_IMPL
+// #define DEBUG_LOG(...) Serial.printf(__VA_ARGS__)
 
 bool handleNewClient(WiFiServer *server, WiFiClient clients[]);
 int pushClient(WiFiClient *client, uint8_t B);
 void handleClient(WiFiClient *client);
 char *status_string();
 void restart();
-const std::string getAdapterJson();
 const std::string getStatusJson();

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -36,6 +36,7 @@ class Mqtt {
 
   void publishHA() const;
 
+#if defined(EBUS_INTERNAL)
   void publishCommands();
   void publishHASensors(const bool remove);
   void publishParticipants();
@@ -45,6 +46,7 @@ class Mqtt {
                           const std::vector<uint8_t> &slave);
 
   static void publishValue(Command *command, const JsonDocument &doc);
+#endif
 
  private:
   AsyncMqttClient client;
@@ -53,6 +55,7 @@ class Mqtt {
 
   bool haSupport = false;
 
+#if defined(EBUS_INTERNAL)
   std::deque<Command> insCommands;
   uint32_t distanceInsert = 300;
   uint32_t lastInsert = 0;
@@ -72,6 +75,7 @@ class Mqtt {
   std::deque<const Participant *> pubParticipants;
   uint32_t distanceParticipants = 200;
   uint32_t lastParticipants = 0;
+#endif
 
   void setWill(const char *topic, uint8_t qos, bool retain,
                const char *payload = nullptr, size_t length = 0);
@@ -90,6 +94,7 @@ class Mqtt {
 
   static void onPublish(uint16_t packetId) {}
 
+#if defined(EBUS_INTERNAL)
   void insertCommands(const JsonArray &commands);
   void removeCommands(const JsonArray &keys);
 
@@ -107,15 +112,18 @@ class Mqtt {
   static void initScan(const bool full, const JsonArray &addresses);
 
   void publishCommand(const Command *command);
+#endif
 
   void publishHADiagnostic(const char *name, const bool remove,
                            const char *value_template, const bool full = false);
 
   void publishHAConfigButton(const char *name, const bool remove);
 
+#if defined(EBUS_INTERNAL)
   void publishHASensor(const Command *command, const bool remove);
 
   void publishParticipant(const Participant *participant);
+#endif
 };
 
 extern Mqtt mqtt;

--- a/include/schedule.hpp
+++ b/include/schedule.hpp
@@ -35,7 +35,7 @@ class Schedule {
   void setDistance(const uint8_t distance);
 
   void handleScanFull();
-  void handleScanSeen();
+  void handleScan();
   void handleScanAddresses(const JsonArray &addresses);
 
   void handleSend(const JsonArray &commands);

--- a/include/schedule.hpp
+++ b/include/schedule.hpp
@@ -51,6 +51,11 @@ class Schedule {
   void fetchCounters();
   const std::string getCountersJson();
 
+  void setPublishTimings(const bool enable);
+  void resetTimings();
+  void fetchTimings();
+  const std::string getTimingsJson();
+
   static JsonDocument getParticipantJson(const Participant *participant);
   const std::string getParticipantsJson() const;
 
@@ -79,6 +84,7 @@ class Schedule {
   std::vector<std::vector<uint8_t>> forwardfilters;
 
   bool publishCounters = false;
+  bool publishTimings = false;
 
   static void onWriteCallback(const uint8_t byte);
   static int isDataAvailableCallback();

--- a/include/store.hpp
+++ b/include/store.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined(EBUS_INTERNAL)
 #include <ArduinoJson.h>
 #include <Ebus.h>
 
@@ -94,3 +95,4 @@ class Store {
 };
 
 extern Store store;
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#1315c87
+    https://github.com/yuhu-/ebus#c875061
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#685a46c
+    https://github.com/yuhu-/ebus#27eb868
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,12 +16,10 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#c875061
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1
     -DIOTWEBCONF_PASSWORD_LEN=64
-    -DEBUS_INTERNAL=1
 
 [env:esp12e]
 platform = espressif8266
@@ -87,3 +85,28 @@ upload_protocol = espota
 extends = env:esp32-c3-ota
 upload_protocol = custom
 upload_command = scp $SOURCE root@10.9.0.6:firmware.bin && ssh root@10.9.0.6 espota.py -i esp-ebus.local -p 3232 -f firmware.bin -d -r
+
+[env:esp32-c3-internal]
+platform = espressif32@6.5.0
+board = esp32-c3-devkitm-1
+board_build.partitions = min_spiffs.csv
+build_flags =
+    ${env.build_flags}
+    -DRESET_PIN=20
+    -DPWM_PIN=6
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBusSer=Serial1
+    -DDebugSer=Serial
+    -DSTATUS_LED_PIN=3
+    -DEBUS_INTERNAL=1
+
+monitor_filters = esp32_exception_decoder
+lib_deps =
+    ${env.lib_deps}
+    https://github.com/yuhu-/ebus#f7b69c5
+
+[env:esp32-c3-internal-ota]
+extends = env:esp32-c3-internal
+upload_port = esp-ebus.local
+upload_protocol = espota

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#c43e915
+    https://github.com/yuhu-/ebus#baf526f
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#27eb868
+    https://github.com/yuhu-/ebus#c43e915
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ lib_deps =
     https://github.com/prampec/IotWebConf#v3.2.1
     heman/AsyncMqttClient-esphome@^2.1.0
     bblanchon/ArduinoJson@^7.2.0
-    https://github.com/yuhu-/ebus#baf526f
+    https://github.com/yuhu-/ebus#1315c87
 
 build_flags =
     -DIOTWEBCONF_CONFIG_DONT_USE_MDNS=1

--- a/src/busisr.cpp
+++ b/src/busisr.cpp
@@ -1,0 +1,90 @@
+#include "busisr.hpp"
+
+#if defined(EBUS_INTERNAL)
+#include "main.hpp"
+
+hw_timer_t* requestBusTimer = nullptr;
+
+portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
+
+// This value can be adjusted if the bus request is not working as expected.
+volatile uint16_t requestWindow = 4300;  // default 4300us
+volatile bool requestBusPending = false;
+volatile bool requestBusDone = false;
+
+ebus::Bus* bus = nullptr;
+ebus::Queue<uint8_t>* byteQueue = nullptr;
+ebus::Handler* ebusHandler = nullptr;
+ebus::ServiceRunner* serviceRunner = nullptr;
+
+// ISR: Fires when a byte is received
+void IRAM_ATTR onUartRx() {
+  if (!byteQueue || !ebusHandler) return;
+  // Read all available bytes as quickly as possible
+  while (BusSer.available()) {
+    // Pre-calculate start bit time only once per byte
+    uint32_t micorsStartBit = micros() - 4167;  // 4167us = 2400 baud, 10 bit
+    uint8_t byte = BusSer.read();
+
+    // Handle bus request done flag
+    if (requestBusDone) {
+      requestBusDone = false;
+      ebusHandler->busRequested();
+    }
+
+    // Push byte to queue (should be lock-free or ISR-safe)
+    byteQueue->push(byte);
+
+    // Handle bus request logic only if needed
+    if (byte == ebus::sym_syn && ebusHandler->busRequest()) {
+      portENTER_CRITICAL_ISR(&timerMux);
+      int32_t delay = requestWindow - (micros() - micorsStartBit);
+      if (delay > 0) {
+        requestBusPending = true;
+        timerAlarmWrite(requestBusTimer, delay, false);
+        timerAlarmEnable(requestBusTimer);
+      } else {
+        // Only write if TX buffer is empty
+        if (!BusSer.available()) {
+          BusSer.write(ebusHandler->getAddress());
+          requestBusPending = false;
+          requestBusDone = true;
+        }
+      }
+      portEXIT_CRITICAL_ISR(&timerMux);
+    }
+  }
+}
+
+// ISR: Write request byte at the exact time
+void IRAM_ATTR onRequestBusTimer() {
+  portENTER_CRITICAL_ISR(&timerMux);
+  if (requestBusPending && !BusSer.available()) {
+    BusSer.write(ebusHandler->getAddress());
+    requestBusPending = false;
+    requestBusDone = true;
+  }
+  timerAlarmDisable(requestBusTimer);
+  portEXIT_CRITICAL_ISR(&timerMux);
+}
+
+void setupBusIsr() {
+  // Initialize BusSer = Serial1
+  BusSer.begin(2400, SERIAL_8N1, UART_RX, UART_TX);
+
+  bus = new ebus::Bus(BusSer);
+  byteQueue = new ebus::Queue<uint8_t>();
+  ebusHandler = new ebus::Handler(bus, ebus::DEFAULT_ADDRESS);
+  serviceRunner = new ebus::ServiceRunner(*ebusHandler, *byteQueue);
+
+  // Attach the ISR to the UART receive event
+  BusSer.onReceive(onUartRx);
+
+  // Request bus timer: one-shot, armed as needed
+  requestBusTimer = timerBegin(0, 160, true);
+  timerAttachInterrupt(requestBusTimer, &onRequestBusTimer, true);
+  timerAlarmDisable(requestBusTimer);
+}
+
+void setRequestWindow(const uint16_t& delay) { requestWindow = delay; }
+#endif

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -1,6 +1,7 @@
 #include "http.hpp"
 
 #include "main.hpp"
+#include "mqtt.hpp"
 #include "schedule.hpp"
 #include "store.hpp"
 
@@ -210,7 +211,10 @@ void SetupHttpHandlers() {
   configServer.on("/commands/download", [] { handleCommandsDownload(); });
   configServer.on("/commands/upload", [] { handleCommandsUpload(); });
   configServer.on("/commands/insert", [] { handleCommandsInsert(); });
-  configServer.on("/commands/load", [] { handleCommandsLoad(); });
+  configServer.on("/commands/load", [] {
+    handleCommandsLoad();
+    mqtt.publishHASensors(false);
+  });
   configServer.on("/commands/save", [] { handleCommandsSave(); });
   configServer.on("/commands/wipe", [] { handleCommandsWipe(); });
   configServer.on("/values", [] { handleValues(); });

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -119,8 +119,8 @@ void handleValues() {
                     store.getValuesJson().c_str());
 }
 
-void handleParicipantsScanSeen() {
-  schedule.handleScanSeen();
+void handleParicipantsScan() {
+  schedule.handleScan();
   configServer.send(200, "text/html", "Scan initiated");
 }
 
@@ -206,8 +206,7 @@ void SetupHttpHandlers() {
   configServer.on("/commands/save", [] { handleCommandsSave(); });
   configServer.on("/commands/wipe", [] { handleCommandsWipe(); });
   configServer.on("/values", [] { handleValues(); });
-  configServer.on("/participants/scanseen",
-                  [] { handleParicipantsScanSeen(); });
+  configServer.on("/participants/scan", [] { handleParicipantsScan(); });
   configServer.on("/participants/scanfull",
                   [] { handleParicipantsScanFull(); });
   configServer.on("/participants/list", [] { handleParicipantsList(); });

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -9,17 +9,12 @@ WebServer configServer(80);
 
 void handleStatus() { configServer.send(200, "text/plain", status_string()); }
 
-void handleGetAdapter() {
-  configServer.send(200, "application/json;charset=utf-8",
-                    getAdapterJson().c_str());
-}
-
 void handleGetStatus() {
   configServer.send(200, "application/json;charset=utf-8",
                     getStatusJson().c_str());
 }
 
-#ifdef EBUS_INTERNAL
+#if defined(EBUS_INTERNAL)
 void handleCommandsList() {
   configServer.send(200, "application/json;charset=utf-8",
                     store.getCommandsJson().c_str());
@@ -145,7 +140,7 @@ void handleGetTimings() {
                     schedule.getTimingsJson().c_str());
 }
 
-void handleReset() {
+void handleResetStatistic() {
   schedule.resetCounters();
   schedule.resetTimings();
 }
@@ -166,7 +161,7 @@ void handleRoot() {
   s += "  </script>\n";
   s += "</head><body>";
   s += "<a href='/status'>Adapter status</a><br>";
-#ifdef EBUS_INTERNAL
+#if defined(EBUS_INTERNAL)
   s += "<a href='/commands/list'>List commands</a><br>";
   s += "<a href='/commands/upload'>Upload commands</a><br>";
   s += "<a href='/commands/download'>Download commands</a><br>";
@@ -183,7 +178,7 @@ void handleRoot() {
        "confirmAction('scan full');\">Scan full</a><br>";
   s += "<a href='/participants/list'>Participants</a><br>";
   s += "<a href='/reset' onclick=\"return "
-       "confirmAction('reset');\">Reset</a><br>";
+       "confirmAction('reset');\">Reset statistic</a><br>";
 #endif
   s += "<a href='/restart' onclick=\"return "
        "confirmAction('restart');\">Restart</a><br>";
@@ -204,9 +199,8 @@ void SetupHttpHandlers() {
   // -- Set up required URL handlers on the web server.
   configServer.on("/", [] { handleRoot(); });
   configServer.on("/status", [] { handleStatus(); });
-  configServer.on("/api/v1/GetAdapter", [] { handleGetAdapter(); });
   configServer.on("/api/v1/GetStatus", [] { handleGetStatus(); });
-#ifdef EBUS_INTERNAL
+#if defined(EBUS_INTERNAL)
   configServer.on("/commands/list", [] { handleCommandsList(); });
   configServer.on("/commands/download", [] { handleCommandsDownload(); });
   configServer.on("/commands/upload", [] { handleCommandsUpload(); });
@@ -224,7 +218,7 @@ void SetupHttpHandlers() {
   configServer.on("/participants/list", [] { handleParicipantsList(); });
   configServer.on("/api/v1/GetCounters", [] { handleGetCounters(); });
   configServer.on("/api/v1/GetTimings", [] { handleGetTimings(); });
-  configServer.on("/reset", [] { handleReset(); });
+  configServer.on("/reset", [] { handleResetStatistic(); });
 #endif
   configServer.on("/restart", [] { restart(); });
   configServer.on("/config", [] { iotWebConf.handleConfig(); });

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -138,6 +138,10 @@ void handleGetCounters() {
   configServer.send(200, "application/json;charset=utf-8",
                     schedule.getCountersJson().c_str());
 }
+void handleGetTimings() {
+  configServer.send(200, "application/json;charset=utf-8",
+                    schedule.getTimingsJson().c_str());
+}
 #endif
 
 void handleRoot() {
@@ -208,6 +212,7 @@ void SetupHttpHandlers() {
                   [] { handleParicipantsScanFull(); });
   configServer.on("/participants/list", [] { handleParicipantsList(); });
   configServer.on("/api/v1/GetCounters", [] { handleGetCounters(); });
+  configServer.on("/api/v1/GetTimings", [] { handleGetTimings(); });
 #endif
   configServer.on("/restart", [] { restart(); });
   configServer.on("/config", [] { iotWebConf.handleConfig(); });

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -138,9 +138,15 @@ void handleGetCounters() {
   configServer.send(200, "application/json;charset=utf-8",
                     schedule.getCountersJson().c_str());
 }
+
 void handleGetTimings() {
   configServer.send(200, "application/json;charset=utf-8",
                     schedule.getTimingsJson().c_str());
+}
+
+void handleReset() {
+  schedule.resetCounters();
+  schedule.resetTimings();
 }
 #endif
 
@@ -175,6 +181,8 @@ void handleRoot() {
   s += "<a href='/participants/scanfull' onclick=\"return "
        "confirmAction('scan full');\">Scan full</a><br>";
   s += "<a href='/participants/list'>Participants</a><br>";
+  s += "<a href='/reset' onclick=\"return "
+       "confirmAction('reset');\">Reset</a><br>";
 #endif
   s += "<a href='/restart' onclick=\"return "
        "confirmAction('restart');\">Restart</a><br>";
@@ -212,6 +220,7 @@ void SetupHttpHandlers() {
   configServer.on("/participants/list", [] { handleParicipantsList(); });
   configServer.on("/api/v1/GetCounters", [] { handleGetCounters(); });
   configServer.on("/api/v1/GetTimings", [] { handleGetTimings(); });
+  configServer.on("/reset", [] { handleReset(); });
 #endif
   configServer.on("/restart", [] { restart(); });
   configServer.on("/config", [] { iotWebConf.handleConfig(); });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,6 +90,7 @@ char mqtt_server[STRING_LEN];
 char mqtt_user[STRING_LEN];
 char mqtt_pass[STRING_LEN];
 char mqttPublishCountersValue[STRING_LEN];
+char mqttPublishTimingsValue[STRING_LEN];
 
 char haSupportValue[STRING_LEN];
 
@@ -136,6 +137,10 @@ iotwebconf::CheckboxParameter mqttPublishCountersParam =
     iotwebconf::CheckboxParameter("Publish Counters to MQTT",
                                   "mqttPublishCountersParam",
                                   mqttPublishCountersValue, STRING_LEN);
+iotwebconf::CheckboxParameter mqttPublishTimingsParam =
+    iotwebconf::CheckboxParameter("Publish Timings to MQTT",
+                                  "mqttPublishTimingsParam",
+                                  mqttPublishTimingsValue, STRING_LEN);
 
 iotwebconf::ParameterGroup haGroup =
     iotwebconf::ParameterGroup("ha", "Home Assistant configuration");
@@ -383,6 +388,7 @@ void saveParamsCallback() {
   if (mqtt_user[0] != '\0') mqtt.setCredentials(mqtt_user, mqtt_pass);
 
   schedule.setPublishCounters(mqttPublishCountersParam.isChecked());
+  schedule.setPublishTimings(mqttPublishTimingsParam.isChecked());
 
   mqtt.setHASupport(haSupportParam.isChecked());
   mqtt.publishHA();
@@ -456,6 +462,9 @@ char* status_string() {
   pos +=
       snprintf(status + pos, bufferSize - pos, "mqtt_publish_counters: %s\r\n",
                mqttPublishCountersParam.isChecked() ? "true" : "false");
+  pos +=
+      snprintf(status + pos, bufferSize - pos, "mqtt_publish_timings: %s\r\n",
+               mqttPublishTimingsParam.isChecked() ? "true" : "false");
 #endif
 
   pos += snprintf(status + pos, bufferSize - pos, "ha_support: %s\r\n",
@@ -496,6 +505,7 @@ const std::string getAdapterJson() {
   Mqtt["Connected"] = mqtt.connected();
 #ifdef EBUS_INTERNAL
   Mqtt["Publish_Counters"] = mqttPublishCountersParam.isChecked();
+  Mqtt["Publish_Timings"] = mqttPublishTimingsParam.isChecked();
 #endif
 
   // HomeAssistant
@@ -598,6 +608,7 @@ void setup() {
   mqttGroup.addItem(&mqttPasswordParam);
 #ifdef EBUS_INTERNAL
   mqttGroup.addItem(&mqttPublishCountersParam);
+  mqttGroup.addItem(&mqttPublishTimingsParam);
 #endif
 
   haGroup.addItem(&haSupportParam);
@@ -660,6 +671,7 @@ void setup() {
   if (mqtt_user[0] != '\0') mqtt.setCredentials(mqtt_user, mqtt_pass);
 
   schedule.setPublishCounters(mqttPublishCountersParam.isChecked());
+  schedule.setPublishTimings(mqttPublishTimingsParam.isChecked());
 
   mqtt.setHASupport(haSupportParam.isChecked());
 
@@ -718,6 +730,7 @@ void loop() {
 
 #ifdef EBUS_INTERNAL
       schedule.fetchCounters();
+      schedule.fetchTimings();
 #endif
     }
 #ifdef EBUS_INTERNAL

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,6 +231,7 @@ void set_pwm(uint8_t value) {
   ledcWrite(PWM_CHANNEL, value);
 #ifdef EBUS_INTERNAL
   schedule.resetCounters();
+  schedule.resetTimings();
 #endif
 #endif
 }
@@ -445,9 +446,9 @@ char* status_string() {
                   ebus_address);
   pos += snprintf(status + pos, bufferSize - pos, "command_distance: %i\r\n",
                   atoi(command_distance));
-  pos += snprintf(status + pos, bufferSize - pos, "active_commands: %u\r\n",
+  pos += snprintf(status + pos, bufferSize - pos, "active_commands: %zu\r\n",
                   store.getActiveCommands());
-  pos += snprintf(status + pos, bufferSize - pos, "passive_commands: %u\r\n",
+  pos += snprintf(status + pos, bufferSize - pos, "passive_commands: %zu\r\n",
                   store.getPassiveCommands());
 #endif
 

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -304,7 +304,7 @@ void Mqtt::initScan(const bool full, const JsonArray &addresses) {
   if (full)
     schedule.handleScanFull();
   else if (addresses.isNull() || addresses.size() == 0)
-    schedule.handleScanSeen();
+    schedule.handleScan();
   else
     schedule.handleScanAddresses(addresses);
 

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -186,6 +186,12 @@ void Mqtt::onMessage(const char *topic, const char *payload,
       if (!filters.isNull()) schedule.handleForwadFilter(filters);
       boolean value = doc["value"].as<boolean>();
       schedule.toggleForward(value);
+    } else if (id.compare("reset") == 0) {
+      boolean value = doc["value"].as<boolean>();
+      if (value) {
+        schedule.resetCounters();
+        schedule.resetTimings();
+      }
     }
 #endif
     else {  // NOLINT

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -161,7 +161,10 @@ void Mqtt::onMessage(const char *topic, const char *payload,
       if (value) mqtt.publishCommands();
     } else if (id.compare("load") == 0) {
       boolean value = doc["value"].as<boolean>();
-      if (value) loadCommands();
+      if (value) {
+        loadCommands();
+        mqtt.publishHASensors(false);
+      }
     } else if (id.compare("save") == 0) {
       boolean value = doc["value"].as<boolean>();
       if (value) saveCommands();

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -143,7 +143,7 @@ void Schedule::handleScanFull() {
   nextScanCommand();
 }
 
-void Schedule::handleScanSeen() {
+void Schedule::handleScan() {
   scanCommands.clear();
   std::set<uint8_t> slaves;
 

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -92,6 +92,27 @@ TRACK_TIMING(passiveFirst, "passive/first")
 TRACK_TIMING(passiveData, "passive/data")
 TRACK_TIMING(activeFirst, "active/first")
 TRACK_TIMING(activeData, "active/data")
+TRACK_TIMING(resetPassive, "reset/passive");
+TRACK_TIMING(resetActive, "reset/active");
+TRACK_TIMING(callbackWrite, "callback/write");
+TRACK_TIMING(callbackError, "callback/error");
+
+TRACK_TIMING(callbackTelegramPassiveMasterSlave,
+             "callback/telegram/passiveMasterSlave");
+TRACK_TIMING(callbackTelegramPassiveMasterMaster,
+             "callback/telegram/passiveMasterMaster");
+TRACK_TIMING(callbackTelegramReactiveMasterSlave,
+             "callback/telegram/reactiveMasterSlave");
+TRACK_TIMING(callbackTelegramReactiveMasterMaster,
+             "callback/telegram/reactiveMasterMaster");
+TRACK_TIMING(callbackTelegramReactiveBroadcast,
+             "callback/telegram/reactiveBroadcast");
+TRACK_TIMING(callbackTelegramActiveMasterSlave,
+             "callback/telegram/activeMasterSlave");
+TRACK_TIMING(callbackTelegramActiveMasterMaster,
+             "callback/telegram/activeMasterMaster");
+TRACK_TIMING(callbackTelegramActiveBroadcast,
+             "callback/telegram/activeBroadcast");
 
 // FSM state timings
 TRACK_TIMING(passiveReceiveMaster, "fsmstate/passiveReceiveMaster")
@@ -400,6 +421,18 @@ void Schedule::fetchTimings() {
   ASSIGN_TIMING(passiveData)
   ASSIGN_TIMING(activeFirst)
   ASSIGN_TIMING(activeData)
+  ASSIGN_TIMING(resetPassive)
+  ASSIGN_TIMING(resetActive)
+  ASSIGN_TIMING(callbackWrite)
+  ASSIGN_TIMING(callbackError)
+  ASSIGN_TIMING(callbackTelegramPassiveMasterSlave)
+  ASSIGN_TIMING(callbackTelegramPassiveMasterMaster)
+  ASSIGN_TIMING(callbackTelegramReactiveMasterSlave)
+  ASSIGN_TIMING(callbackTelegramReactiveMasterMaster)
+  ASSIGN_TIMING(callbackTelegramReactiveBroadcast)
+  ASSIGN_TIMING(callbackTelegramActiveMasterSlave)
+  ASSIGN_TIMING(callbackTelegramActiveMasterMaster)
+  ASSIGN_TIMING(callbackTelegramActiveBroadcast)
 
   ebus::StateTimingStatsResults stats =
       ebusHandler.getStateTimingStatsResults();
@@ -448,18 +481,79 @@ const std::string Schedule::getTimingsJson() {
 
   addTiming(doc["Sync"].to<JsonObject>(), timings.syncLast, timings.syncMean,
             timings.syncStdDev, timings.syncCount);
+
   addTiming(doc["Passive"]["First"].to<JsonObject>(), timings.passiveFirstLast,
             timings.passiveFirstMean, timings.passiveFirstStdDev,
             timings.passiveFirstCount);
   addTiming(doc["Passive"]["Data"].to<JsonObject>(), timings.passiveDataLast,
             timings.passiveDataMean, timings.passiveDataStdDev,
             timings.passiveDataCount);
+
   addTiming(doc["Active"]["First"].to<JsonObject>(), timings.activeFirstLast,
             timings.activeFirstMean, timings.activeFirstStdDev,
             timings.activeFirstCount);
   addTiming(doc["Active"]["Data"].to<JsonObject>(), timings.activeDataLast,
             timings.activeDataMean, timings.activeDataStdDev,
             timings.activeDataCount);
+
+  addTiming(doc["Reset"]["Passive"].to<JsonObject>(), timings.resetPassiveLast,
+            timings.resetPassiveMean, timings.resetPassiveStdDev,
+            timings.resetPassiveCount);
+  addTiming(doc["Reset"]["Active"].to<JsonObject>(), timings.resetActiveLast,
+            timings.resetActiveMean, timings.resetActiveStdDev,
+            timings.resetActiveCount);
+
+  addTiming(doc["Callback"]["Write"].to<JsonObject>(),
+            timings.callbackWriteLast, timings.callbackWriteMean,
+            timings.callbackWriteStdDev, timings.callbackWriteCount);
+
+  addTiming(doc["Callback"]["Error"].to<JsonObject>(),
+            timings.callbackErrorLast, timings.callbackErrorMean,
+            timings.callbackErrorStdDev, timings.callbackErrorCount);
+
+  addTiming(doc["Callback"]["Telegram"]["passiveMasterSlave"].to<JsonObject>(),
+            timings.callbackTelegramPassiveMasterSlaveLast,
+            timings.callbackTelegramPassiveMasterSlaveMean,
+            timings.callbackTelegramPassiveMasterSlaveStdDev,
+            timings.callbackTelegramPassiveMasterSlaveCount);
+  addTiming(doc["Callback"]["Telegram"]["passiveMasterMaster"].to<JsonObject>(),
+            timings.callbackTelegramPassiveMasterMasterLast,
+            timings.callbackTelegramPassiveMasterMasterMean,
+            timings.callbackTelegramPassiveMasterMasterStdDev,
+            timings.callbackTelegramPassiveMasterMasterCount);
+
+  addTiming(doc["Callback"]["Telegram"]["reactiveMasterSlave"].to<JsonObject>(),
+            timings.callbackTelegramReactiveMasterSlaveLast,
+            timings.callbackTelegramReactiveMasterSlaveMean,
+            timings.callbackTelegramReactiveMasterSlaveStdDev,
+            timings.callbackTelegramReactiveMasterSlaveCount);
+  addTiming(
+      doc["Callback"]["Telegram"]["reactiveMasterMaster"].to<JsonObject>(),
+      timings.callbackTelegramReactiveMasterMasterLast,
+      timings.callbackTelegramReactiveMasterMasterMean,
+      timings.callbackTelegramReactiveMasterMasterStdDev,
+      timings.callbackTelegramReactiveMasterMasterCount);
+  addTiming(doc["Callback"]["Telegram"]["reactiveBroadcast"].to<JsonObject>(),
+            timings.callbackTelegramReactiveBroadcastLast,
+            timings.callbackTelegramReactiveBroadcastMean,
+            timings.callbackTelegramReactiveBroadcastStdDev,
+            timings.callbackTelegramReactiveBroadcastCount);
+
+  addTiming(doc["Callback"]["Telegram"]["activeMasterSlave"].to<JsonObject>(),
+            timings.callbackTelegramActiveMasterSlaveLast,
+            timings.callbackTelegramActiveMasterSlaveMean,
+            timings.callbackTelegramActiveMasterSlaveStdDev,
+            timings.callbackTelegramActiveMasterSlaveCount);
+  addTiming(doc["Callback"]["Telegram"]["activeMasterMaster"].to<JsonObject>(),
+            timings.callbackTelegramActiveMasterMasterLast,
+            timings.callbackTelegramActiveMasterMasterMean,
+            timings.callbackTelegramActiveMasterMasterStdDev,
+            timings.callbackTelegramActiveMasterMasterCount);
+  addTiming(doc["Callback"]["Telegram"]["activeBroadcast"].to<JsonObject>(),
+            timings.callbackTelegramActiveBroadcastLast,
+            timings.callbackTelegramActiveBroadcastMean,
+            timings.callbackTelegramActiveBroadcastStdDev,
+            timings.callbackTelegramActiveBroadcastCount);
 
   ebus::StateTimingStatsResults stats =
       ebusHandler.getStateTimingStatsResults();

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -21,61 +21,104 @@ const std::vector<uint8_t> SCAN_b5090127 = {0xb5, 0x09, 0x01, 0x27};
 std::map<uint8_t, uint32_t> seenMasters;
 std::map<uint8_t, uint32_t> seenSlaves;
 
-// ebus/<unique_id>/state/messages
-Track<uint32_t> messagesTotal("state/messages", 10);
+#define TRACK_U32(NAME, PATH) Track<uint32_t> NAME("state/" PATH, 10);
 
-Track<uint32_t> messagesPassiveMasterSlave("state/messages/passiveMasterSlave",
-                                           10);
-Track<uint32_t> messagesPassiveMasterMaster(
-    "state/messages/passiveMasterMaster", 10);
+#define ASSIGN_COUNTER(NAME) NAME = counters.NAME;
 
-Track<uint32_t> messagesReactiveMasterSlave(
-    "state/messages/reactiveMasterSlave", 10);
-Track<uint32_t> messagesReactiveMasterMaster(
-    "state/messages/reactiveMasterMaster", 10);
-Track<uint32_t> messagesReactiveBroadcast("state/messages/reactiveBroadcast",
-                                          10);
+// Messages
+TRACK_U32(messagesTotal, "messages")
+TRACK_U32(messagesPassiveMasterSlave, "messages/passiveMasterSlave")
+TRACK_U32(messagesPassiveMasterMaster, "messages/passiveMasterMaster")
+TRACK_U32(messagesReactiveMasterSlave, "messages/reactiveMasterSlave")
+TRACK_U32(messagesReactiveMasterMaster, "messages/reactiveMasterMaster")
+TRACK_U32(messagesReactiveBroadcast, "messages/reactiveBroadcast")
+TRACK_U32(messagesActiveMasterSlave, "messages/activeMasterSlave")
+TRACK_U32(messagesActiveMasterMaster, "messages/activeMasterMaster")
+TRACK_U32(messagesActiveBroadcast, "messages/activeBroadcast")
 
-Track<uint32_t> messagesActiveMasterSlave("state/messages/activeMasterSlave",
-                                          10);
-Track<uint32_t> messagesActiveMasterMaster("state/messages/activeMasterMaster",
-                                           10);
-Track<uint32_t> messagesActiveBroadcast("state/messages/activeBroadcast", 10);
+// Requests
+TRACK_U32(requestsTotal, "requests")
+TRACK_U32(requestsWon, "requests/won")
+TRACK_U32(requestsLost, "requests/lost")
+TRACK_U32(requestsRetry, "requests/retry")
+TRACK_U32(requestsError, "requests/error")
 
-// ebus/<unique_id>/state/requests
-Track<uint32_t> requestsTotal("state/requests", 10);
-Track<uint32_t> requestsWon("state/requests/won", 10);
-Track<uint32_t> requestsLost("state/requests/lost", 10);
-Track<uint32_t> requestsRetry("state/requests/retry", 10);
-Track<uint32_t> requestsError("state/requests/error", 10);
+// Resets
+TRACK_U32(resetsTotal, "resets")
+TRACK_U32(resetsPassive00, "resets/passive00")
+TRACK_U32(resetsPassive0704, "resets/passive0704")
+TRACK_U32(resetsPassive, "resets/passive")
+TRACK_U32(resetsActive, "resets/active")
 
-// ebus/<unique_id>/state/resets
-Track<uint32_t> resetsTotal("state/resets", 10);
-Track<uint32_t> resetsPassive00("state/resets/passive00", 10);
-Track<uint32_t> resetsPassive0704("state/resets/passive0704", 10);
-Track<uint32_t> resetsPassive("state/resets/passive", 10);
-Track<uint32_t> resetsActive("state/resets/active", 10);
+// Errors
+TRACK_U32(errorsTotal, "errors")
+TRACK_U32(errorsPassive, "errors/passive")
+TRACK_U32(errorsPassiveMaster, "errors/passive/master")
+TRACK_U32(errorsPassiveMasterACK, "errors/passive/masterACK")
+TRACK_U32(errorsPassiveSlave, "errors/passive/slave")
+TRACK_U32(errorsPassiveSlaveACK, "errors/passive/slaveACK")
+TRACK_U32(errorsReactive, "errors/reactive")
+TRACK_U32(errorsReactiveMaster, "errors/reactive/master")
+TRACK_U32(errorsReactiveMasterACK, "errors/reactive/masterACK")
+TRACK_U32(errorsReactiveSlave, "errors/reactive/slave")
+TRACK_U32(errorsReactiveSlaveACK, "errors/reactive/slaveACK")
+TRACK_U32(errorsActive, "errors/active")
+TRACK_U32(errorsActiveMaster, "errors/active/master")
+TRACK_U32(errorsActiveMasterACK, "errors/active/masterACK")
+TRACK_U32(errorsActiveSlave, "errors/active/slave")
+TRACK_U32(errorsActiveSlaveACK, "errors/active/slaveACK")
 
-// ebus/<unique_id>/state/errors
-Track<uint32_t> errorsTotal("state/errors", 10);
+#define TRACK_TIMING(NAME, PATH)                                    \
+  Track<int64_t> NAME##Last("state/timings/" PATH "/last", 10);     \
+  Track<int64_t> NAME##Mean("state/timings/" PATH "/mean", 10);     \
+  Track<int64_t> NAME##StdDev("state/timings/" PATH "/stddev", 10); \
+  Track<uint64_t> NAME##Count("state/timings/" PATH "/count", 10);
 
-Track<uint32_t> errorsPassive("state/errors/passive", 10);
-Track<uint32_t> errorsPassiveMaster("state/errors/passive/master", 10);
-Track<uint32_t> errorsPassiveMasterACK("state/errors/passive/masterACK", 10);
-Track<uint32_t> errorsPassiveSlave("state/errors/passive/slave", 10);
-Track<uint32_t> errorsPassiveSlaveACK("state/errors/passive/slaveACK", 10);
+#define ASSIGN_TIMING(NAME)            \
+  NAME##Last = timings.NAME##Last;     \
+  NAME##Mean = timings.NAME##Mean;     \
+  NAME##StdDev = timings.NAME##StdDev; \
+  NAME##Count = timings.NAME##Count;
 
-Track<uint32_t> errorsReactive("state/errors/reactive", 10);
-Track<uint32_t> errorsReactiveMaster("state/errors/reactive/master", 10);
-Track<uint32_t> errorsReactiveMasterACK("state/errors/reactive/masterACK", 10);
-Track<uint32_t> errorsReactiveSlave("state/errors/reactive/slave", 10);
-Track<uint32_t> errorsReactiveSlaveACK("state/errors/reactive/slaveACK", 10);
+#define ASSIGN_STATE_TIMING(NAME, STATE_ENUM)                     \
+  NAME##Last = stats.states[ebus::FsmState::STATE_ENUM].last;     \
+  NAME##Mean = stats.states[ebus::FsmState::STATE_ENUM].mean;     \
+  NAME##StdDev = stats.states[ebus::FsmState::STATE_ENUM].stddev; \
+  NAME##Count = stats.states[ebus::FsmState::STATE_ENUM].count;
 
-Track<uint32_t> errorsActive("state/errors/active", 10);
-Track<uint32_t> errorsActiveMaster("state/errors/active/master", 10);
-Track<uint32_t> errorsActiveMasterACK("state/errors/active/masterACK", 10);
-Track<uint32_t> errorsActiveSlave("state/errors/active/slave", 10);
-Track<uint32_t> errorsActiveSlaveACK("state/errors/active/slaveACK", 10);
+// General timings
+TRACK_TIMING(sync, "sync")
+TRACK_TIMING(passiveFirst, "passive/first")
+TRACK_TIMING(passiveData, "passive/data")
+TRACK_TIMING(activeFirst, "active/first")
+TRACK_TIMING(activeData, "active/data")
+
+// FSM state timings
+TRACK_TIMING(passiveReceiveMaster, "fsmstate/passiveReceiveMaster")
+TRACK_TIMING(passiveReceiveMasterAcknowledge,
+             "fsmstate/passiveReceiveMasterAcknowledge")
+TRACK_TIMING(passiveReceiveSlave, "fsmstate/passiveReceiveSlave")
+TRACK_TIMING(passiveReceiveSlaveAcknowledge,
+             "fsmstate/passiveReceiveSlaveAcknowledge")
+TRACK_TIMING(reactiveSendMasterPositiveAcknowledge,
+             "fsmstate/reactiveSendMasterPositiveAcknowledge")
+TRACK_TIMING(reactiveSendMasterNegativeAcknowledge,
+             "fsmstate/reactiveSendMasterNegativeAcknowledge")
+TRACK_TIMING(reactiveSendSlave, "fsmstate/reactiveSendSlave")
+TRACK_TIMING(reactiveReceiveSlaveAcknowledge,
+             "fsmstate/reactiveReceiveSlaveAcknowledge")
+TRACK_TIMING(requestBusFirstTry, "fsmstate/requestBusFirstTry")
+TRACK_TIMING(requestBusPriorityRetry, "fsmstate/requestBusPriorityRetry")
+TRACK_TIMING(requestBusSecondTry, "fsmstate/requestBusSecondTry")
+TRACK_TIMING(activeSendMaster, "fsmstate/activeSendMaster")
+TRACK_TIMING(activeReceiveMasterAcknowledge,
+             "fsmstate/activeReceiveMasterAcknowledge")
+TRACK_TIMING(activeReceiveSlave, "fsmstate/activeReceiveSlave")
+TRACK_TIMING(activeSendSlavePositiveAcknowledge,
+             "fsmstate/activeSendSlavePositiveAcknowledge")
+TRACK_TIMING(activeSendSlaveNegativeAcknowledge,
+             "fsmstate/activeSendSlaveNegativeAcknowledge")
+TRACK_TIMING(releaseBus, "fsmstate/releaseBus");
 
 Schedule schedule;
 
@@ -199,73 +242,66 @@ void Schedule::resetCounters() {
 }
 
 void Schedule::fetchCounters() {
-  if (publishCounters) {
-    // Addresses Master
-    for (std::pair<const uint8_t, uint32_t> &master : seenMasters) {
-      std::string topic =
-          "state/addresses/master/" + ebus::to_string(master.first);
-      mqtt.publish(topic.c_str(), 0, false, String(master.second).c_str());
-    }
+  if (!publishCounters) return;
 
-    // Addresses Slave
-    for (std::pair<const uint8_t, uint32_t> &slave : seenSlaves) {
-      std::string topic =
-          "state/addresses/slave/" + ebus::to_string(slave.first);
-      mqtt.publish(topic.c_str(), 0, false, String(slave.second).c_str());
-    }
-
-    // Counters
-    ebus::Counters counters = ebusHandler.getCounters();
-
-    // Messages
-    messagesTotal = counters.messagesTotal;
-
-    messagesPassiveMasterSlave = counters.messagesPassiveMasterSlave;
-    messagesPassiveMasterMaster = counters.messagesPassiveMasterMaster;
-
-    messagesReactiveMasterSlave = counters.messagesReactiveMasterSlave;
-    messagesReactiveMasterMaster = counters.messagesReactiveMasterMaster;
-    messagesReactiveBroadcast = counters.messagesReactiveBroadcast;
-
-    messagesActiveMasterSlave = counters.messagesActiveMasterSlave;
-    messagesActiveMasterMaster = counters.messagesActiveMasterMaster;
-    messagesActiveBroadcast = counters.messagesActiveBroadcast;
-
-    // Requests
-    requestsTotal = counters.requestsTotal;
-    requestsWon = counters.requestsWon;
-    requestsLost = counters.requestsLost;
-    requestsRetry = counters.requestsRetry;
-    requestsError = counters.requestsError;
-
-    // Resets
-    resetsTotal = counters.resetsTotal;
-    resetsPassive00 = counters.resetsPassive00;
-    resetsPassive0704 = counters.resetsPassive0704;
-    resetsPassive = counters.resetsPassive;
-    resetsActive = counters.resetsActive;
-
-    // Errors
-    errorsTotal = counters.errorsTotal;
-
-    errorsPassive = counters.errorsPassive;
-    errorsPassiveMaster = counters.errorsPassiveMaster;
-    errorsPassiveMasterACK = counters.errorsPassiveMasterACK;
-    errorsPassiveSlave = counters.errorsPassiveSlave;
-    errorsPassiveSlaveACK = counters.errorsPassiveSlaveACK;
-
-    errorsReactive = counters.errorsReactive;
-    errorsReactiveMaster = counters.errorsReactiveMaster;
-    errorsReactiveMasterACK = counters.errorsReactiveMasterACK;
-    errorsReactiveSlave = counters.errorsReactiveSlave;
-    errorsReactiveSlaveACK = counters.errorsReactiveSlaveACK;
-
-    errorsActive = counters.errorsActive;
-    errorsActiveMaster = counters.errorsActiveMaster;
-    errorsActiveMasterACK = counters.errorsActiveMasterACK;
-    errorsActiveSlave = counters.errorsActiveSlave;
-    errorsActiveSlaveACK = counters.errorsActiveSlaveACK;
+  // Addresses Master
+  for (std::pair<const uint8_t, uint32_t> &master : seenMasters) {
+    std::string topic =
+        "state/addresses/master/" + ebus::to_string(master.first);
+    mqtt.publish(topic.c_str(), 0, false, String(master.second).c_str());
   }
+
+  // Addresses Slave
+  for (std::pair<const uint8_t, uint32_t> &slave : seenSlaves) {
+    std::string topic = "state/addresses/slave/" + ebus::to_string(slave.first);
+    mqtt.publish(topic.c_str(), 0, false, String(slave.second).c_str());
+  }
+
+  // Counters
+  ebus::Counters counters = ebusHandler.getCounters();
+
+  // Messages
+  ASSIGN_COUNTER(messagesTotal)
+  ASSIGN_COUNTER(messagesPassiveMasterSlave)
+  ASSIGN_COUNTER(messagesPassiveMasterMaster)
+  ASSIGN_COUNTER(messagesReactiveMasterSlave)
+  ASSIGN_COUNTER(messagesReactiveMasterMaster)
+  ASSIGN_COUNTER(messagesReactiveBroadcast)
+  ASSIGN_COUNTER(messagesActiveMasterSlave)
+  ASSIGN_COUNTER(messagesActiveMasterMaster)
+  ASSIGN_COUNTER(messagesActiveBroadcast)
+
+  // Requests
+  ASSIGN_COUNTER(requestsTotal)
+  ASSIGN_COUNTER(requestsWon)
+  ASSIGN_COUNTER(requestsLost)
+  ASSIGN_COUNTER(requestsRetry)
+  ASSIGN_COUNTER(requestsError)
+
+  // Resets
+  ASSIGN_COUNTER(resetsTotal)
+  ASSIGN_COUNTER(resetsPassive00)
+  ASSIGN_COUNTER(resetsPassive0704)
+  ASSIGN_COUNTER(resetsPassive)
+  ASSIGN_COUNTER(resetsActive)
+
+  // Errors
+  ASSIGN_COUNTER(errorsTotal)
+  ASSIGN_COUNTER(errorsPassive)
+  ASSIGN_COUNTER(errorsPassiveMaster)
+  ASSIGN_COUNTER(errorsPassiveMasterACK)
+  ASSIGN_COUNTER(errorsPassiveSlave)
+  ASSIGN_COUNTER(errorsPassiveSlaveACK)
+  ASSIGN_COUNTER(errorsReactive)
+  ASSIGN_COUNTER(errorsReactiveMaster)
+  ASSIGN_COUNTER(errorsReactiveMasterACK)
+  ASSIGN_COUNTER(errorsReactiveSlave)
+  ASSIGN_COUNTER(errorsReactiveSlaveACK)
+  ASSIGN_COUNTER(errorsActive)
+  ASSIGN_COUNTER(errorsActiveMaster)
+  ASSIGN_COUNTER(errorsActiveMasterACK)
+  ASSIGN_COUNTER(errorsActiveSlave)
+  ASSIGN_COUNTER(errorsActiveSlaveACK)
 }
 
 const std::string Schedule::getCountersJson() {
@@ -342,6 +378,144 @@ const std::string Schedule::getCountersJson() {
   Errors_Active["Master_ACK"] = counters.errorsActiveMasterACK;
   Errors_Active["Slave"] = counters.errorsActiveSlave;
   Errors_Active["Slave_ACK"] = counters.errorsActiveSlaveACK;
+
+  doc.shrinkToFit();
+  serializeJson(doc, payload);
+
+  return payload;
+}
+
+void Schedule::setPublishTimings(const bool enable) { publishTimings = enable; }
+
+void Schedule::resetTimings() { ebusHandler.resetTimings(); }
+
+void Schedule::fetchTimings() {
+  if (!publishTimings) return;
+
+  // Timings
+  ebus::Timings timings = ebusHandler.getTimings();
+
+  ASSIGN_TIMING(sync)
+  ASSIGN_TIMING(passiveFirst)
+  ASSIGN_TIMING(passiveData)
+  ASSIGN_TIMING(activeFirst)
+  ASSIGN_TIMING(activeData)
+
+  ebus::StateTimingStatsResults stats =
+      ebusHandler.getStateTimingStatsResults();
+
+  ASSIGN_STATE_TIMING(passiveReceiveMaster, passiveReceiveMaster)
+  ASSIGN_STATE_TIMING(passiveReceiveMasterAcknowledge,
+                      passiveReceiveMasterAcknowledge)
+  ASSIGN_STATE_TIMING(passiveReceiveSlave, passiveReceiveSlave)
+  ASSIGN_STATE_TIMING(passiveReceiveSlaveAcknowledge,
+                      passiveReceiveSlaveAcknowledge)
+  ASSIGN_STATE_TIMING(reactiveSendMasterPositiveAcknowledge,
+                      reactiveSendMasterPositiveAcknowledge)
+  ASSIGN_STATE_TIMING(reactiveSendMasterNegativeAcknowledge,
+                      reactiveSendMasterNegativeAcknowledge)
+  ASSIGN_STATE_TIMING(reactiveSendSlave, reactiveSendSlave)
+  ASSIGN_STATE_TIMING(reactiveReceiveSlaveAcknowledge,
+                      reactiveReceiveSlaveAcknowledge)
+  ASSIGN_STATE_TIMING(requestBusFirstTry, requestBusFirstTry)
+  ASSIGN_STATE_TIMING(requestBusPriorityRetry, requestBusPriorityRetry)
+  ASSIGN_STATE_TIMING(requestBusSecondTry, requestBusSecondTry)
+  ASSIGN_STATE_TIMING(activeSendMaster, activeSendMaster)
+  ASSIGN_STATE_TIMING(activeReceiveMasterAcknowledge,
+                      activeReceiveMasterAcknowledge)
+  ASSIGN_STATE_TIMING(activeReceiveSlave, activeReceiveSlave)
+  ASSIGN_STATE_TIMING(activeSendSlavePositiveAcknowledge,
+                      activeSendSlavePositiveAcknowledge)
+  ASSIGN_STATE_TIMING(activeSendSlaveNegativeAcknowledge,
+                      activeSendSlaveNegativeAcknowledge)
+  ASSIGN_STATE_TIMING(releaseBus, releaseBus)
+}
+
+const std::string Schedule::getTimingsJson() {
+  std::string payload;
+  JsonDocument doc;
+
+  ebus::Timings timings = ebusHandler.getTimings();
+
+  // Helper lambda to add timing stats to a JsonObject
+  auto addTiming = [](JsonObject obj, int64_t last, int64_t mean,
+                      int64_t stddev, uint64_t count) {
+    obj["Last"] = last;
+    obj["Mean"] = mean;
+    obj["StdDev"] = stddev;
+    obj["Count"] = count;
+  };
+
+  addTiming(doc["Sync"].to<JsonObject>(), timings.syncLast, timings.syncMean,
+            timings.syncStdDev, timings.syncCount);
+  addTiming(doc["Passive"]["First"].to<JsonObject>(), timings.passiveFirstLast,
+            timings.passiveFirstMean, timings.passiveFirstStdDev,
+            timings.passiveFirstCount);
+  addTiming(doc["Passive"]["Data"].to<JsonObject>(), timings.passiveDataLast,
+            timings.passiveDataMean, timings.passiveDataStdDev,
+            timings.passiveDataCount);
+  addTiming(doc["Active"]["First"].to<JsonObject>(), timings.activeFirstLast,
+            timings.activeFirstMean, timings.activeFirstStdDev,
+            timings.activeFirstCount);
+  addTiming(doc["Active"]["Data"].to<JsonObject>(), timings.activeDataLast,
+            timings.activeDataMean, timings.activeDataStdDev,
+            timings.activeDataCount);
+
+  ebus::StateTimingStatsResults stats =
+      ebusHandler.getStateTimingStatsResults();
+
+  // Output FSM state timings
+  auto addStateTiming =
+      [](JsonObject obj,
+         const ebus::StateTimingStatsResults::StateStats &state) {
+        obj["Last"] = static_cast<int64_t>(state.last);
+        obj["Mean"] = static_cast<int64_t>(state.mean);
+        obj["StdDev"] = static_cast<int64_t>(state.stddev);
+        obj["Count"] = state.count;
+      };
+
+  addStateTiming(doc["FsmState"]["passiveReceiveMaster"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::passiveReceiveMaster));
+  addStateTiming(
+      doc["FsmState"]["passiveReceiveMasterAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::passiveReceiveMasterAcknowledge));
+  addStateTiming(doc["FsmState"]["passiveReceiveSlave"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::passiveReceiveSlave));
+  addStateTiming(
+      doc["FsmState"]["passiveReceiveSlaveAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::passiveReceiveSlaveAcknowledge));
+  addStateTiming(
+      doc["FsmState"]["reactiveSendMasterPositiveAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::reactiveSendMasterPositiveAcknowledge));
+  addStateTiming(
+      doc["FsmState"]["reactiveSendMasterNegativeAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::reactiveSendMasterNegativeAcknowledge));
+  addStateTiming(doc["FsmState"]["reactiveSendSlave"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::reactiveSendSlave));
+  addStateTiming(
+      doc["FsmState"]["reactiveReceiveSlaveAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::reactiveReceiveSlaveAcknowledge));
+  addStateTiming(doc["FsmState"]["requestBusFirstTry"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::requestBusFirstTry));
+  addStateTiming(doc["FsmState"]["requestBusPriorityRetry"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::requestBusPriorityRetry));
+  addStateTiming(doc["FsmState"]["requestBusSecondTry"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::requestBusSecondTry));
+  addStateTiming(doc["FsmState"]["activeSendMaster"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::activeSendMaster));
+  addStateTiming(
+      doc["FsmState"]["activeReceiveMasterAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::activeReceiveMasterAcknowledge));
+  addStateTiming(doc["FsmState"]["activeReceiveSlave"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::activeReceiveSlave));
+  addStateTiming(
+      doc["FsmState"]["activeSendSlavePositiveAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::activeSendSlavePositiveAcknowledge));
+  addStateTiming(
+      doc["FsmState"]["activeSendSlaveNegativeAcknowledge"].to<JsonObject>(),
+      stats.states.at(ebus::FsmState::activeSendSlaveNegativeAcknowledge));
+  addStateTiming(doc["FsmState"]["releaseBus"].to<JsonObject>(),
+                 stats.states.at(ebus::FsmState::releaseBus));
 
   doc.shrinkToFit();
   serializeJson(doc, payload);

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -215,10 +215,12 @@ std::vector<Command *> Store::updateData(Command *command,
                                          const std::vector<uint8_t> &slave) {
   std::vector<Command *> commands;
 
-  if (command == nullptr)
+  if (command == nullptr) {
     commands = findPassiveCommands(master);
-  else
+  } else {
+    commands.reserve(1);
     commands.push_back(command);
+  }
 
   for (Command *cmd : commands) {
     cmd->last = millis();

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -1,3 +1,4 @@
+#if defined(EBUS_INTERNAL)
 #include "store.hpp"
 
 #include <Preferences.h>
@@ -428,3 +429,4 @@ const double Store::getValueDouble(const Command *command) {
 const std::string Store::getValueString(const Command *command) {
   return ebus::byte_2_string(command->data);
 }
+#endif

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -37,37 +37,64 @@ Command Store::createCommand(const JsonDocument &doc) {
 }
 
 void Store::insertCommand(const Command &command) {
-  std::string key = command.key;
-  const std::vector<Command>::iterator it =
-      std::find_if(allCommands.begin(), allCommands.end(),
-                   [&key](const Command &cmd) { return cmd.key == key; });
+  // Insert or update in allCommandsByKey
+  std::unordered_map<std::string, Command>::iterator it =
+      allCommandsByKey.find(command.key);
+  if (it != allCommandsByKey.end())
+    it->second = command;
+  else
+    allCommandsByKey.insert(std::make_pair(command.key, command));
 
-  if (it != allCommands.end()) {
-    *it = command;
-  } else {
-    allCommands.push_back(command);
-    countCommands();
+  // Remove from previous index if exists
+  for (std::unordered_map<std::vector<uint8_t>, Command *, VectorHash>::iterator
+           itp = passiveCommands.begin();
+       itp != passiveCommands.end();) {
+    if (itp->second->key == command.key)
+      itp = passiveCommands.erase(itp);
+    else
+      ++itp;
   }
+
+  activeCommands.erase(
+      std::remove_if(
+          activeCommands.begin(), activeCommands.end(),
+          [&](const Command *cmd) { return cmd->key == command.key; }),
+      activeCommands.end());
+
+  // Add to passive or active index
+  Command *cmdPtr = &allCommandsByKey[command.key];
+  if (command.active)
+    activeCommands.push_back(cmdPtr);
+  else
+    passiveCommands[command.command] = cmdPtr;
 }
 
 void Store::removeCommand(const std::string &key) {
-  const std::vector<Command>::const_iterator it =
-      std::find_if(allCommands.cbegin(), allCommands.cend(),
-                   [&key](const Command &cmd) { return cmd.key == key; });
-
-  if (it != allCommands.end()) {
-    allCommands.erase(it);
-    countCommands();
+  std::unordered_map<std::string, Command>::iterator it =
+      allCommandsByKey.find(key);
+  if (it != allCommandsByKey.end()) {
+    // Remove from indexes
+    for (std::unordered_map<std::vector<uint8_t>, Command *,
+                            VectorHash>::iterator itp = passiveCommands.begin();
+         itp != passiveCommands.end();) {
+      if (itp->second->key == key)
+        itp = passiveCommands.erase(itp);
+      else
+        ++itp;
+    }
+    activeCommands.erase(
+        std::remove_if(activeCommands.begin(), activeCommands.end(),
+                       [&](const Command *cmd) { return cmd->key == key; }),
+        activeCommands.end());
+    allCommandsByKey.erase(it);
   }
 }
 
 const Command *Store::findCommand(const std::string &key) {
-  const std::vector<Command>::const_iterator it =
-      std::find_if(allCommands.cbegin(), allCommands.cend(),
-                   [&key](const Command &cmd) { return cmd.key == key; });
-
-  if (it != allCommands.end())
-    return &(*it);
+  std::unordered_map<std::string, Command>::iterator it =
+      allCommandsByKey.find(key);
+  if (it != allCommandsByKey.end())
+    return &(it->second);
   else
     return nullptr;
 }
@@ -148,9 +175,9 @@ const std::string Store::getCommandsJson() const {
   std::string payload;
   JsonDocument doc;
 
-  if (allCommands.size() > 0) {
-    for (const Command &command : allCommands)
-      doc.add(getCommandJson(&command));
+  if (!allCommandsByKey.empty()) {
+    for (const std::pair<const std::string, Command> &kv : allCommandsByKey)
+      doc.add(getCommandJson(&kv.second));
   }
 
   if (doc.isNull()) doc.to<JsonArray>();
@@ -163,37 +190,35 @@ const std::string Store::getCommandsJson() const {
 
 const std::vector<Command *> Store::getCommands() {
   std::vector<Command *> commands;
-  for (Command &command : allCommands) commands.push_back(&(command));
+  for (std::pair<const std::string, Command> &kv : allCommandsByKey)
+    commands.push_back(&(kv.second));
   return commands;
 }
 
-const size_t Store::getActiveCommands() const { return activeCommands; }
-const size_t Store::getPassiveCommands() const { return passiveCommands; }
+const size_t Store::getActiveCommands() const { return activeCommands.size(); }
 
-const bool Store::active() const { return activeCommands > 0; }
+const size_t Store::getPassiveCommands() const {
+  return passiveCommands.size();
+}
+
+const bool Store::active() const { return !activeCommands.empty(); }
 
 Command *Store::nextActiveCommand() {
   Command *next = nullptr;
   bool init = false;
-
-  for (Command &cmd : allCommands) {
-    if (cmd.active) {
-      if (cmd.last == 0) {
-        next = &cmd;
-        init = true;
-        break;
-      }
-
-      if (next == nullptr) {
-        next = &cmd;
-      } else {
-        if (cmd.last + cmd.interval * 1000 < next->last + next->interval * 1000)
-          next = &cmd;
-      }
+  for (Command *cmd : activeCommands) {
+    if (cmd->last == 0) {
+      next = cmd;
+      init = true;
+      break;
     }
+    if (next == nullptr ||
+        (cmd->last + cmd->interval * 1000 < next->last + next->interval * 1000))
+      next = cmd;
   }
 
-  if (!init && millis() < next->last + next->interval * 1000) next = nullptr;
+  if (!init && next && millis() < next->last + next->interval * 1000)
+    next = nullptr;
 
   return next;
 }
@@ -201,12 +226,18 @@ Command *Store::nextActiveCommand() {
 std::vector<Command *> Store::findPassiveCommands(
     const std::vector<uint8_t> &master) {
   std::vector<Command *> commands;
-
-  for (Command &command : allCommands) {
-    if (!command.active && ebus::contains(master, command.command))
-      commands.push_back(&(command));
+  // Fast lookup by command pattern
+  std::unordered_map<std::vector<uint8_t>, Command *, VectorHash>::iterator it =
+      passiveCommands.find(master);
+  if (it != passiveCommands.end()) {
+    commands.push_back(it->second);
+  } else {
+    // fallback: scan for all that match (if needed)
+    for (const std::pair<const std::vector<uint8_t>, Command *> &kv :
+         passiveCommands) {
+      if (ebus::contains(master, kv.first)) commands.push_back(kv.second);
+    }
   }
-
   return commands;
 }
 
@@ -252,11 +283,12 @@ const std::string Store::getValuesJson() const {
 
   JsonArray results = doc["results"].to<JsonArray>();
 
-  if (allCommands.size() > 0) {
+  if (!allCommandsByKey.empty()) {
     size_t index = 0;
     uint32_t now = millis();
 
-    for (const Command &command : allCommands) {
+    for (const std::pair<const std::string, Command> &kv : allCommandsByKey) {
+      const Command &command = kv.second;
       JsonArray array = results[index][command.key].to<JsonArray>();
       if (command.numeric)
         array.add(store.getValueDouble(&command));
@@ -278,19 +310,13 @@ const std::string Store::getValuesJson() const {
   return payload;
 }
 
-void Store::countCommands() {
-  activeCommands = std::count_if(allCommands.begin(), allCommands.end(),
-                                 [](const Command &cmd) { return cmd.active; });
-
-  passiveCommands = allCommands.size() - activeCommands;
-}
-
 const std::string Store::serializeCommands() const {
   std::string payload;
   JsonDocument doc;
 
-  if (allCommands.size() > 0) {
-    for (const Command &command : allCommands) {
+  if (!allCommandsByKey.empty()) {
+    for (const std::pair<const std::string, Command> &kv : allCommandsByKey) {
+      const Command &command = kv.second;
       JsonArray array = doc.add<JsonArray>();
 
       array.add(command.key);


### PR DESCRIPTION
Over the past few weeks, I've revised the eBUS library and fixed timing and logical issues.

The changes resulted in a modified structure and task distribution, which is (currently) only supported with freeRTOS (ESP32). 

    I decided to use only HardwareSerial for serial access.
    Bus access is controlled via ISR and delivers the data to a byteQueue. 
    A dedicated serviceRunner processes this in the handler (FSM). 
    Any output is processed via eventQueue in the waiting scheduleTask.

For this purpose, I've added two new profiles as follows:

    [env:esp32-c3-internal]
    [env:esp32-c3-internal-ota]

EBUS_INTERNAL now truly means internal only. 

    Read access to port 3334 is supported. 
    Write access via port 3333 and port 3335 is disabled. 
    Status queries via port 5555 are also possible.
    The other profiles are now as before (without schedule, store,...but with basic mqtt support)
