### PR TITLE
Use vertical text in commands table

### DIFF
--- a/static/commands.html
+++ b/static/commands.html
@@ -6,6 +6,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>esp-eBus Commands</title>
   <link rel="stylesheet" href="common.css">
+  <style>
+    /* Vertical headers only for the commands table (scoped locally to this page) */
+    #commandsTable th {
+      writing-mode: vertical-lr;
+      -webkit-writing-mode: vertical-lr;
+      text-orientation: mixed;
+      white-space: nowrap;
+      vertical-align: bottom;
+      padding: 10px 6px;
+      font-size: 12px;
+      min-width: 36px;
+    }
+  </style>
 </head>
 
 <body>

--- a/static/common.css
+++ b/static/common.css
@@ -145,19 +145,6 @@ td {
     padding: 0px;
 }
 
-/* Vertical headers only for the commands table (avoid affecting other pages like values.html) */
-#commandsTable th {
-    /* vertical header text for compact table headers (left-to-right vertical) */
-    writing-mode: vertical-lr;
-    -webkit-writing-mode: vertical-lr;
-    text-orientation: mixed;
-    white-space: nowrap;
-    vertical-align: bottom;
-    padding: 10px 6px;
-    font-size: 12px;
-    min-width: 36px;
-}
-
 /* ========== Textarea and Box Sizing ========== */
 textarea {
     width: 100%;


### PR DESCRIPTION
to maximize the amount of columns visible