### PR TITLE
Use full hash ref for ebus lib

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -73,7 +73,7 @@ board_build.embed_txtfiles =
 
 lib_deps = 
     ${env.lib_deps}
-    https://github.com/yuhu-/ebus#67f46e2
+    https://github.com/yuhu-/ebus.git#67f46e2510553a7debf56d746251694b92b463ac
 
 [env:esp32-c3-internal-ota]
 extends = env:esp32-c3-internal


### PR DESCRIPTION
due to problems with platformio fetching the lib
```
Library Manager: Installing git+[https://github.com/yuhu-/ebus.git#67f46e2](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
git version 2.43.0
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: git branch -m <name>
Initialized empty Git repository in /home/danman/.platformio/.cache/tmp/pkg-installing-enqrtxls/.git/
fatal: couldn't find remote ref 67f46e2
VCSBaseException: VCS: Could not process command ['git', 'fetch', '--depth=1', 'origin', '67f46e2']
```
```