### PR TITLE
POC PsychicMqttClient (based on espressif esp-mqtt)

### DIFF
--- a/include/Mqtt.hpp
+++ b/include/Mqtt.hpp
@@ -2,7 +2,7 @@
 
 #if defined(EBUS_INTERNAL)
 #include <ArduinoJson.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 
 #include <queue>
 #include <string>
@@ -75,7 +75,7 @@ class Mqtt {
   const bool isEnabled() const;
 
   void connect();
-  const bool connected() const;
+  const bool connected();
 
   void disconnect();
 
@@ -93,7 +93,7 @@ class Mqtt {
   void doLoop();
 
  private:
-  AsyncMqttClient client;
+  PsychicMqttClient client;
   std::string uniqueId;
   std::string rootTopic;
   std::string willTopic;
@@ -134,16 +134,19 @@ class Mqtt {
   uint16_t subscribe(const char* topic, uint8_t qos);
 
   static void onConnect(bool sessionPresent);
-  static void onDisconnect(AsyncMqttClientDisconnectReason reason) {}
+  // static void onDisconnect(AsyncMqttClientDisconnectReason reason) {}
 
-  static void onSubscribe(uint16_t packetId, uint8_t qos) {}
-  static void onUnsubscribe(uint16_t packetId) {}
+  // static void onSubscribe(uint16_t packetId, uint8_t qos) {}
+  // static void onUnsubscribe(uint16_t packetId) {}
 
-  static void onMessage(const char* topic, const char* payload,
-                        AsyncMqttClientMessageProperties properties, size_t len,
-                        size_t index, size_t total);
+  // static void onMessage(const char* topic, const char* payload,
+  //                       AsyncMqttClientMessageProperties properties, size_t
+  //                       len, size_t index, size_t total);
 
-  static void onPublish(uint16_t packetId) {}
+  static void onMessage(char* topic, char* payload, int retain, int qos,
+                        bool dup);
+
+  // static void onPublish(uint16_t packetId) {}
 
   // Command handlers
   static void handleRestart(const JsonDocument& doc);

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ monitor_filters = esp32_exception_decoder
 extra_scripts = pre:auto_firmware_version.py
 lib_deps = 
     https://github.com/prampec/IotWebConf#v3.2.1
-    heman/AsyncMqttClient-esphome@^2.1.0
+    elims/PsychicMqttClient@^0.2.4
     bblanchon/ArduinoJson@^7.2.0
 
 build_flags =

--- a/src/Mqtt.cpp
+++ b/src/Mqtt.cpp
@@ -10,11 +10,11 @@ Mqtt mqtt;
 
 Mqtt::Mqtt() {
   client.onConnect(onConnect);
-  client.onDisconnect(onDisconnect);
-  client.onSubscribe(onSubscribe);
-  client.onUnsubscribe(onUnsubscribe);
+  // client.onDisconnect(onDisconnect);
+  // client.onSubscribe(onSubscribe);
+  // client.onUnsubscribe(onUnsubscribe);
   client.onMessage(onMessage);
-  client.onPublish(onPublish);
+  // client.onPublish(onPublish);
 }
 
 void Mqtt::setUniqueId(const char* id) {
@@ -31,7 +31,8 @@ const std::string& Mqtt::getRootTopic() const { return rootTopic; }
 const std::string& Mqtt::getWillTopic() const { return willTopic; }
 
 void Mqtt::setServer(const char* host, uint16_t port) {
-  client.setServer(host, port);
+  // client.setServer(host, port);
+  client.setServer("mqtt://HOSTNAME_OR_IP:1883");
 }
 
 void Mqtt::setCredentials(const char* username, const char* password) {
@@ -44,7 +45,7 @@ const bool Mqtt::isEnabled() const { return enabled; }
 
 void Mqtt::connect() { client.connect(); }
 
-const bool Mqtt::connected() const { return client.connected(); }
+const bool Mqtt::connected() { return client.connected(); }
 
 void Mqtt::disconnect() { client.disconnect(); }
 
@@ -53,7 +54,7 @@ uint16_t Mqtt::publish(const char* topic, uint8_t qos, bool retain,
   if (!enabled) return 0;
 
   std::string mqttTopic = prefix ? rootTopic + topic : topic;
-  return client.publish(mqttTopic.c_str(), qos, retain, payload);
+  return client.publish(mqttTopic.c_str(), qos, retain, payload, 0, false);
 }
 
 void Mqtt::enqueueOutgoing(const OutgoingAction& action) {
@@ -111,9 +112,8 @@ void Mqtt::onConnect(bool sessionPresent) {
   if (mqttha.isEnabled()) mqttha.publishDeviceInfo();
 }
 
-void Mqtt::onMessage(const char* topic, const char* payload,
-                     AsyncMqttClientMessageProperties properties, size_t len,
-                     size_t index, size_t total) {
+void Mqtt::onMessage(char* topic, char* payload, int retain, int qos,
+                     bool dup) {
   JsonDocument doc;
   DeserializationError error = deserializeJson(doc, payload);
 


### PR DESCRIPTION
Size increased from
`RAM:   [==        ]  16.9% (used 55508 bytes from 327680 bytes)`
`Flash: [=======   ]  69.6% (used 1367426 bytes from 1966080 bytes)`
to
`RAM:   [==        ]  17.1% (used 55980 bytes from 327680 bytes)`
`Flash: [========  ]  76.1% (used 1495678 bytes from 1966080 bytes)`

Asynchronous transmission is limited. Instead, a message is transmitted immediately.

I would use esp-mqtt directly instead of another library.