### PR TITLE
3 repetitions each for bus request and sending added

### DIFF
--- a/include/Schedule.hpp
+++ b/include/Schedule.hpp
@@ -120,6 +120,9 @@ class Schedule {
 
   std::map<uint8_t, Device> devices;
 
+  uint32_t busRequestFailed = 0;
+  uint32_t sendingFailed = 0;
+
   bool forward = false;
   std::vector<std::vector<uint8_t>> forwardfilters;
 


### PR DESCRIPTION
Bus requests and transmissions are repeated up to a maximum of three times for each command, with the exception of full scan commands. This should help to resolve the issue of an active command not being sent.