### PR TITLE
add firmware builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,10 +93,6 @@ jobs:
       needs: build
       runs-on: ubuntu-latest
       steps:
-        - name: Checkout gh-pages branch
-          uses: actions/checkout@v4
-          with:
-            ref: gh-pages
             
         - name: Download artifacts
           uses: actions/download-artifact@v4


### PR DESCRIPTION
firmware is available over http at:
```
http://esp-ebus.gh.danman.eu/firmware/<sha>/firmware-HW_v5.x-[internal]-<sha>.bin
```
http://esp-ebus.gh.danman.eu/firmware/7246b3/firmware-HW_v5.x-internal-7246b3.bin