### PR TITLE
fix(mqtt-ha): remove stale loop_duration discovery sensor

### DIFF
--- a/include/MqttHA.hpp
+++ b/include/MqttHA.hpp
@@ -95,7 +95,6 @@ class MqttHA {
   Component createDiagnosticResetCode() const;
   Component createDiagnosticUptime() const;
   Component createDiagnosticFreeHeap() const;
-  Component createDiagnosticLoopDuration() const;
   Component createDiagnosticRSSI() const;
 };
 

--- a/src/MqttHA.cpp
+++ b/src/MqttHA.cpp
@@ -47,7 +47,6 @@ void MqttHA::publishDeviceInfo() const {
   mqttha.publishComponent(createDiagnosticResetCode(), !enabled);
   mqttha.publishComponent(createDiagnosticUptime(), !enabled);
   mqttha.publishComponent(createDiagnosticFreeHeap(), !enabled);
-  mqttha.publishComponent(createDiagnosticLoopDuration(), !enabled);
   mqttha.publishComponent(createDiagnosticRSSI(), !enabled);
 }
 
@@ -354,15 +353,6 @@ MqttHA::Component MqttHA::createDiagnosticFreeHeap() const {
   c.fields["unit_of_measurement"] = "B";
   c.fields["value_template"] = "{{value_json.free_heap}}";
   c.fields["icon"] = "mdi:memory";
-  return c;
-}
-
-MqttHA::Component MqttHA::createDiagnosticLoopDuration() const {
-  Component c = createDiagnostic("sensor", "loop_duration", "Loop Duration");
-  c.fields["state_topic"] = createStateTopic("", "state");
-  c.fields["unit_of_measurement"] = "µs";
-  c.fields["value_template"] = "{{value_json.loop_duration}}";
-  c.fields["icon"] = "mdi:timelapse";
   return c;
 }
 


### PR DESCRIPTION
## Summary
- `getMqttStatusJson()` (main.cpp) builds `ebus/state` with `reset_code`, `uptime`, `free_heap`, `rssi` — `loop_duration` was dropped from this payload in #253.
- `MqttHA::createDiagnosticLoopDuration()` still registers a Home Assistant MQTT-discovery sensor whose `value_template` reads `{{value_json.loop_duration}}`, a key the payload no longer contains.
- Because the discovery config is retained on the broker, Home Assistant recreates the sensor on every adapter reconnect. Each subsequent `ebus/state` message then fails template rendering, producing a repeating WARNING in the HA log (`'dict object' has no attribute 'loop_duration'`), roughly every ~10s at the adapter's publish interval — the sensor itself is permanently stuck at `unknown`.
- Removes `createDiagnosticLoopDuration()`, its call site in `publishDeviceInfo()`, and its header declaration, since the underlying data no longer exists.

## Test plan
- [x] Confirmed no other references to `createDiagnosticLoopDuration`/`loop_duration` remain in `src/`/`include/`.
- [x] Reproduced the underlying WARNING against a live adapter (firmware v7.2) + Home Assistant instance before writing the fix.
- [ ] No local ESP-IDF/PlatformIO toolchain available to build here — relying on CI (`build.yml`) to confirm compilation.