### PR TITLE
fix(deps): pin patched ebus fork to fix crash on /api/v1/commands/save

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -59,9 +59,9 @@ build_flags =
     -DPWM_PIN=6
     -DEBUS_INTERNAL=1
 
-lib_deps = 
+lib_deps =
     ${env.lib_deps}
-    https://github.com/yuhu-/ebus.git#14869188cce168d96892d92fb5471cd4342e69a2
+    https://github.com/macraj/ebus.git#4deff5b5274306e35574fe2169e8a83fc82af4be
 
 [env:esp32-c3-internal-ota]
 extends = env:esp32-c3-internal


### PR DESCRIPTION
## Summary

Fixes the reproducible crash reported in #335 and #351: `POST /api/v1/commands/save`
aborts the device and reboots it, wiping the entire command list (not just the
newly-saved entries).

## Root cause

`esp32-c3-internal` pins `yuhu-/ebus` at commit `14869188c` (2026-03-16). At that
commit, `BusFreeRtos::s_onFallingEdge`/`s_onBusIsrTimer` (the GPIO/timer ISR
trampolines) are correctly marked `IRAM_ATTR`, and the GPIO ISR service is
installed with `ESP_INTR_FLAG_IRAM` — but the actual instance methods they
immediately call, `onFallingEdge()` and `onBusIsrTimer()`, are **not** marked
`IRAM_ATTR`. Since these are separate (non-inlined) functions, the CPU ends up
needing to fetch flash-resident instructions from inside an ISR. If that ISR
fires while flash cache happens to be disabled — which is exactly what happens
during any flash write, including `Store::saveCommands()` — the result is a
"Cache error: Cached memory region accessed while ibus or cache is disabled"
panic. This matches the symptom and diagnosis in yuhu-/ebus#14 ("Interrupt
handlers causing crash"), and explains why it's intermittent/timing-dependent
(only crashes if an eBUS interrupt happens to land inside the cache-disabled
window) — matching #351's "flash write race condition" title.

Confirmed this same gap is already fixed on `yuhu-/ebus` current `master}`
(`onFallingEdge`/`onBusIsrTimer` are `IRAM_ATTR` in the refactored
`bus_esp.cpp`) — but that library has since undergone a full namespace/directory
refactor incompatible with this project's current integration code, so bumping
straight to `master` isn't a safe drop-in here.

## Fix

Forked `yuhu-/ebus` at the exact same pinned commit
(`macraj/ebus@4deff5b`, branched from `14869188c`) and applied the minimal
`IRAM_ATTR` fix on top — same base, only the ISR-safety attributes added:
- `BusFreeRtos::onFallingEdge()` / `onBusIsrTimer()` marked `IRAM_ATTR`
  (declaration + definition)
- `Request::busRequestAddress()` (called from `onBusIsrTimer()`) inlined in
  the header instead of left as a separate non-IRAM translation unit, since
  `Request.hpp` is shared/portable code without ESP-IDF headers available for
  `IRAM_ATTR` directly

This PR just repoints `platformio.ini`'s `esp32-c3-internal` lib_deps at that
patched commit. No other changes.

## Test plan
- [x] `pio run -e esp32-c3-internal` builds cleanly against the patched fork
      (Flash 85.7%, RAM 14.5% — effectively identical to the unpatched build)
- [x] Verified the fetched dependency in `.pio/libdeps` actually contains the
      `IRAM_ATTR` additions before building
- [ ] Not yet verified against a live device reboot-under-`commands/save` repro
      (no serial/JTAG access on hand) — would appreciate someone who can
      reproduce #335 confirming this resolves it